### PR TITLE
Add airdrop accounts command

### DIFF
--- a/cmd/junod/cmd/airdrop.go
+++ b/cmd/junod/cmd/airdrop.go
@@ -119,7 +119,7 @@ Example:
 				return err
 			}
 
-			// Read Poll file
+			// Read exchanges file
 			exchangeJSON, err := os.Open(exchangeFile)
 			if err != nil {
 				return err
@@ -194,7 +194,7 @@ Example:
 
 				val := validators[delegation.ValidatorAddress.String()]
 
-				// If an account was delegated to an exchange skip
+				// Skip delegations to exchanges
 				if exchangeMap[sdk.AccAddress(delegation.ValidatorAddress.Bytes()).String()] {
 					continue
 				}
@@ -262,10 +262,6 @@ Example:
 
 	return cmd
 }
-
-const (
-	flagGenesisTime     = "genesis-time"
-)
 
 // AddAirdropAccounts Add balances of accounts to genesis, based on cosmos hub snapshot file
 func AddAirdropAccounts()  *cobra.Command {
@@ -389,10 +385,6 @@ $ %s add-airdrop-accounts /path/to/snapshot.json
 			return genutil.ExportGenesisFile(genDoc, genFile)
 		},
 	}
-
-	cmd.Flags().String(flagGenesisTime, "", "override genesis_time with this flag")
-	cmd.Flags().String(flags.FlagChainID, "", "override chain_id with this flag")
-	
 
 	return cmd
 }

--- a/cmd/junod/cmd/airdrop.go
+++ b/cmd/junod/cmd/airdrop.go
@@ -142,6 +142,7 @@ Example:
 			snapshot := make(map[string]SnapshotFields)
 
 			totalAtomBalance := sdk.NewInt(0)
+			totalStakedAtom := sdk.NewInt(0)
 			for _, account := range genStateV036.AppState.Accounts {
 
 				balance := account.Coins.AmountOf(denom)
@@ -203,6 +204,7 @@ Example:
 				acc.AtomBalance = acc.AtomBalance.Add(stakedAtoms)
 				acc.AtomStakedBalance = acc.AtomStakedBalance.Add(stakedAtoms)
 
+				totalStakedAtom = totalStakedAtom.Add(stakedAtoms)
 				snapshot[address] = acc
 			}
 
@@ -240,8 +242,11 @@ Example:
 
 			fmt.Printf("cosmos accounts: %d\n", len(snapshot))
 			fmt.Printf("atomTotalSupply: %s\n", totalAtomBalance.String())
+			fmt.Printf("total staked atoms: %s\n", totalStakedAtom.String())
 			fmt.Printf("extra whale amounts: %s\n", extraWhaleAmounts.String())
+			fmt.Printf("total juno airdrop: %s\n", totalJunoBalance.String())
 
+			
 			// export snapshot json
 			snapshotJSON, err := aminoCodec.MarshalJSON(snapshot)
 			if err != nil {
@@ -317,6 +322,7 @@ $ %s add-airdrop-accounts /path/to/snapshot.json
 
 			count := 0
 			for address, acc := range snapshot {
+				count++;
 
 				// Skip empty accounts
 				if (acc.JunoBalance.LTE(sdk.NewInt(0))) {
@@ -343,8 +349,6 @@ $ %s add-airdrop-accounts /path/to/snapshot.json
 				accs = append(accs, genAccount)
 
 				bankGenState.Balances = append(bankGenState.Balances, balances)
-
-				count++;
 
 				if (count % 1000 == 0) {
 					fmt.Printf("Progress (%d of %d)\n", count, len(snapshot))

--- a/cmd/junod/cmd/airdrop.go
+++ b/cmd/junod/cmd/airdrop.go
@@ -333,7 +333,7 @@ $ %s add-airdrop-accounts /path/to/snapshot.json
 
 			bankGenState := banktypes.GetGenesisStateFromAppState(depCdc, appState)
 
-			fmt.Printf("Account da convertire %d", len(snapshot))
+			fmt.Printf("Accounts %d\n", len(snapshot))
 
 			count := 0
 			for address, acc := range snapshot {
@@ -356,10 +356,8 @@ $ %s add-airdrop-accounts /path/to/snapshot.json
 				genAccount := authtypes.NewBaseAccount(addr, nil, 0, 0)
 
 				accs = append(accs, genAccount)
-				accs = authtypes.SanitizeGenesisAccounts(accs)
 
 				bankGenState.Balances = append(bankGenState.Balances, balances)
-				bankGenState.Balances = banktypes.SanitizeGenesisBalances(bankGenState.Balances)
 
 				count++;
 
@@ -368,6 +366,9 @@ $ %s add-airdrop-accounts /path/to/snapshot.json
 				}
 			}
 
+			fmt.Println("Done! Sorting...")
+			accs = authtypes.SanitizeGenesisAccounts(accs)
+			bankGenState.Balances = banktypes.SanitizeGenesisBalances(bankGenState.Balances)
 
 			genAccs, err := authtypes.PackAccounts(accs)
 			if err != nil {

--- a/cmd/junod/cmd/root.go
+++ b/cmd/junod/cmd/root.go
@@ -39,6 +39,7 @@ import (
 	"github.com/CosmWasm/wasmd/x/wasm"
 )
 
+// ChainID id
 var ChainID string
 
 // NewRootCmd creates a new root command for simd. It is called once in the
@@ -90,6 +91,7 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig) {
 		genutilcli.ValidateGenesisCmd(app.ModuleBasics),
 		AddGenesisAccountCmd(app.DefaultNodeHome),
 		ExportAirdropSnapshotCmd(),
+		AddAirdropAccounts(),
 		tmcli.NewCompletionCmd(rootCmd, true),
 		debug.Cmd(),
 		// this line is used by starport scaffolding # stargate/root/commands

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Juno
 
-![Juno Github Banner](https://user-images.githubusercontent.com/79812965/114168789-05854780-9931-11eb-8c8e-bb9d0486c978.png)
+![JUNO BANNER TEXT](https://user-images.githubusercontent.com/79812965/114202416-73446a00-9957-11eb-9cfc-cfec3d0b56ea.png)
 
 An **interoperable smart contract hub** which automatically executes, controls or documents a procedure of relevant events and actions 
 according to the terms of such contract or agreement to be valid & usable across multiple sovereign networks.
@@ -87,7 +87,7 @@ The community has proposed the following parameters for the network and native a
 
 🟣 **Community pool tax**: 5% of block rewards
 
-![Juno Twitter Logo](https://user-images.githubusercontent.com/79812965/114168144-29945900-9930-11eb-9407-809bab1d2e07.png)
+![JUNO BANNER](https://user-images.githubusercontent.com/79812965/114202517-8ce5b180-9957-11eb-842f-584a2d729b2b.png)
 
 **Proposed JUNO inflation reward shedule**
 

--- a/readme.md
+++ b/readme.md
@@ -37,31 +37,31 @@ and to provide utility in the deployment and execution of smart contracts.
 
 **What differentiates JUNO from other Smart Contract networks?**
 
-🟣 Interoperable smart contracts 
+⚫️ Interoperable smart contracts 
 
-🟣 Modularity
+⚫️ Modularity
 
-🟣 Wasm + (EVM)
+⚫️ Wasm + (EVM)
 
-🟣 Compilation in multiple languages Rust & Go (C,C++)
+⚫️ Compilation in multiple languages Rust & Go (C,C++)
 
-🟣 High scalability
+⚫️ High scalability
 
-🟣 Ease of use
+⚫️ Ease of use
 
-🟣 Fee balancing (Upper & lower bound)
+⚫️ Fee balancing (Upper & lower bound)
 
-🟣 Free & fair asset distribution 100% to staked atom only
+⚫️ Free & fair asset distribution 100% to staked atom only
 
-🟣 Balanced governance (Zero top heavy control) 
+⚫️ Balanced governance (Zero top heavy control) 
                                                      
-🟣 Value sharing model linked to smart contract usage
+⚫️ Value sharing model linked to smart contract usage
                                                   
-🟣 Permissionless 
+⚫️ Permissionless 
                                                      
-🟣 Decentralized
+⚫️ Decentralized
                                              
-🟣 Censorship resistant
+⚫️ Censorship resistant
 
 
 **Distribution**
@@ -79,13 +79,13 @@ A whale cap was voted in by the community, effectively hard-capping $ATOM accoun
 The community has proposed the following parameters for the network and native asset (subject to change before genesis based on community polling):
 
 
-🟣 **Ticker**: JUNO
+⚫️ **Ticker**: JUNO
 
-🟣 **Supply**: Snapshot of Cosmoshub-3 at 06:00 PM UTC on Feb 18th 2021
+⚫️ **Supply**: Snapshot of Cosmoshub-3 at 06:00 PM UTC on Feb 18th 2021
 
-🟣 **Inflation**: Fixed yearly inflation (Reward model below)
+⚫️ **Inflation**: Fixed yearly inflation (Reward model below)
 
-🟣 **Community pool tax**: 5% of block rewards
+⚫️ **Community pool tax**: 5% of block rewards
 
 ![JUNO BANNER](https://user-images.githubusercontent.com/79812965/114202517-8ce5b180-9957-11eb-842f-584a2d729b2b.png)
 
@@ -95,35 +95,35 @@ The community has proposed the following parameters for the network and native a
 
 Initial fixed inflation 40% (+ 107.334.259,2)
 
-🟣 After year 1: 375669907.2 JUNO 
+⚫️ After year 1: 375669907.2 JUNO 
 
 Inflation reduction to 20% (+75.133.981,44)
 
-🟣 After year 2: 450803888.64 JUNO
+⚫️ After year 2: 450803888.64 JUNO
 
 Inflation reduction to 10% (+45.080.388,864)
 
-🟣 After year 3: 495884277.504 JUNO
+⚫️ After year 3: 495884277.504 JUNO
 
 Once the inflation reaches 10% it reduces on a fixed 1% basis each year.
 
-🟣 Year 4 = 9% (+44.629.584,975) Supply = 540513862.479 JUNO
+⚫️ Year 4 = 9% (+44.629.584,975) Supply = 540513862.479 JUNO
 
-🟣 Year 5 = 8% (+43.241.108,99832) Supply = 583754971.47732 JUNO
+⚫️ Year 5 = 8% (+43.241.108,99832) Supply = 583754971.47732 JUNO
 
-🟣 Year 6 = 7% (+40.862.848,00341) Supply = 624617819.48073 JUNO
+⚫️ Year 6 = 7% (+40.862.848,00341) Supply = 624617819.48073 JUNO
 
-🟣 Year 7 = 6% (+37.477.069,16884) Supply = 662094888.64957 JUNO
+⚫️ Year 7 = 6% (+37.477.069,16884) Supply = 662094888.64957 JUNO
 
-🟣 Year 8 = 5% (+33.104.744,43248) Supply = 695199633.08205 JUNO
+⚫️ Year 8 = 5% (+33.104.744,43248) Supply = 695199633.08205 JUNO
 
-🟣 Year 9 = 4% (+27.807.985,32328) Supply = 723007618.40533 JUNO
+⚫️ Year 9 = 4% (+27.807.985,32328) Supply = 723007618.40533 JUNO
 
-🟣 Year 10 = 3% (+21.690.228,55216) Supply = 744697846.95749 JUNO
+⚫️ Year 10 = 3% (+21.690.228,55216) Supply = 744697846.95749 JUNO
 
-🟣 Year 11 = 2% (+14.893.956,93915) Supply = 759591803.89664 JUNO
+⚫️ Year 11 = 2% (+14.893.956,93915) Supply = 759591803.89664 JUNO
 
-🟣 Year 12 = 1% (+7.595.918,03897) Supply = 767187721.93561 JUNO MAX SUPPLY
+⚫️ Year 12 = 1% (+7.595.918,03897) Supply = 767187721.93561 JUNO MAX SUPPLY
 
 After year 12 the inflation reward shedule ends. 
 Network incentives would primarily come from smart contract usage & regular tx fees generated on the network.

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Juno
 
-![photo_2021-03-03_18-10-06](https://user-images.githubusercontent.com/79812965/110179648-ba938400-7e08-11eb-849c-a8da02c31a21.jpg)
+![Juno Banner (2)](https://user-images.githubusercontent.com/79812965/114168087-12556b80-9930-11eb-8b84-6e73dcb43660.png)
 
 An **interoperable smart contract hub** which automatically executes, controls or documents a procedure of relevant events and actions 
 according to the terms of such contract or agreement to be valid & usable across multiple sovereign networks.
@@ -63,8 +63,6 @@ and to provide utility in the deployment and execution of smart contracts.
                                              
 🟣 Censorship resistant
 
-![photo_2021-03-03_18-22-29](https://user-images.githubusercontent.com/79812965/110187125-8a9fad00-7e17-11eb-971f-1b56faf3e558.jpg)
-
 
 **Distribution**
 
@@ -89,7 +87,7 @@ The community has proposed the following parameters for the network and native a
 
 🟣 **Community pool tax**: 5% of block rewards
 
-![JUNO (LOGO 3)](https://user-images.githubusercontent.com/79812965/110180550-4b1e9400-7e0a-11eb-8386-ef1f5a9252f9.png)
+![Juno Twitter Logo](https://user-images.githubusercontent.com/79812965/114168144-29945900-9930-11eb-9407-809bab1d2e07.png)
 
 **Proposed JUNO inflation reward shedule**
 

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Juno
 
-![Juno Github Banner](https://user-images.githubusercontent.com/79812965/114168589-bf2fe880-9930-11eb-9547-045603058c38.png)
+![Juno Github Banner](https://user-images.githubusercontent.com/79812965/114168789-05854780-9931-11eb-8c8e-bb9d0486c978.png)
 
 An **interoperable smart contract hub** which automatically executes, controls or documents a procedure of relevant events and actions 
 according to the terms of such contract or agreement to be valid & usable across multiple sovereign networks.

--- a/readme.md
+++ b/readme.md
@@ -157,6 +157,7 @@ To launch your blockchain live on mutliple nodes use `starport network` commands
 
 ## Learn more
 
+- [Juno](https://junochain.com)
 - [Starport](https://github.com/tendermint/starport)
 - [Cosmos SDK documentation](https://docs.cosmos.network)
 - [Cosmos SDK Tutorials](https://tutorials.cosmos.network)

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Juno
 
-![Juno Banner (2)](https://user-images.githubusercontent.com/79812965/114168087-12556b80-9930-11eb-8b84-6e73dcb43660.png)
+![Juno Github Banner](https://user-images.githubusercontent.com/79812965/114168589-bf2fe880-9930-11eb-9547-045603058c38.png)
 
 An **interoperable smart contract hub** which automatically executes, controls or documents a procedure of relevant events and actions 
 according to the terms of such contract or agreement to be valid & usable across multiple sovereign networks.

--- a/readme.md
+++ b/readme.md
@@ -85,7 +85,7 @@ The community has proposed the following parameters for the network and native a
 
 🟣 **Supply**: Snapshot of Cosmoshub-3 at 06:00 PM UTC on Feb 18th 2021
 
-🟣 **Inflation**: Dynamic 15-40%
+🟣 **Inflation**: Fixed yearly inflation (Reward model below)
 
 🟣 **Community pool tax**: 5% of block rewards
 


### PR DESCRIPTION
Procedure

- Export snapshot with `junod export-airdrop-snapshot [airdrop-to-denom] [input-genesis-file] [input-exchange-addresses] [output-snapshot-json] --juno-supply=[juno-genesis-supply]`
- Init genesis with `junod init <moniker> --chain-id juno-1` 
- Import airdrop accounts with `add-airdrop-accounts [airdrop-snapshot-file] [denom]`
- Fix other parameters by hand (genesis time, other accounts, gentxs.. )