### PR TITLE
Enable stargate feature

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -368,7 +368,7 @@ func New(
 
 	// The last arguments can contain custom message handlers, and custom query handlers,
 	// if we want to allow any custom callbacks
-	supportedFeatures := "staking"
+	supportedFeatures := "staking,stargate"
 	app.wasmKeeper = wasm.NewKeeper(
 		appCodec,
 		keys[wasm.StoreKey],


### PR DESCRIPTION
Allow ibc-related functionality.

Error message:
```
Execute error: Error when broadcasting tx 8DC6EB1ECE54CA9EA603AFD1209FF6D5CCB231A630836C8CAB476582FCF5234D at 
height 694256. Code: 2; Raw log: failed to execute message; message index: 0: Error calling the VM: Error during static Wasm 
validation: Wasm contract requires unsupported features: {"stargate"}: create wasm contract failed
```