### PR TITLE
Fix Juno home in docker setup script

### DIFF
--- a/docker/run_junod.sh
+++ b/docker/run_junod.sh
@@ -2,7 +2,7 @@
 
 if test -n "$1"; then
     # need -R not -r to copy hidden files
-    cp -R "$1/.junod" /root
+    cp -R "$1/.juno" /root
 fi
 
 mkdir -p /root/log

--- a/docker/setup_junod.sh
+++ b/docker/setup_junod.sh
@@ -9,9 +9,9 @@ MONIKER=${MONIKER:-node001}
 
 junod init --chain-id "$CHAIN_ID" "$MONIKER"
 # staking/governance token is hardcoded in config, change this
-sed -i "s/\"stake\"/\"$STAKE\"/" "$HOME"/.junod/config/genesis.json
+sed -i "s/\"stake\"/\"$STAKE\"/" "$HOME"/.juno/config/genesis.json
 # this is essential for sub-1s block times (or header times go crazy)
-sed -i 's/"time_iota_ms": "1000"/"time_iota_ms": "10"/' "$HOME"/.junod/config/genesis.json
+sed -i 's/"time_iota_ms": "1000"/"time_iota_ms": "10"/' "$HOME"/.juno/config/genesis.json
 
 if ! junod keys show validator; then
   (echo "$PASSWORD"; echo "$PASSWORD") | junod keys add validator


### PR DESCRIPTION
Juno default homepath is `"$HOME"/.juno/`
https://github.com/CosmosContracts/Juno/blob/1af28c37ef1c0fe3985a4006ca94f093f4f35f1b/app/app.go#L193