### PR TITLE
Update makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ COMMIT := $(shell git log -1 --format='%H')
 
 # don't override user values
 ifeq (,$(VERSION))
-  VERSION := $(shell git describe --tags --match 'v[0-9]\.[0-9]\.[0-9]')
+  VERSION := $(shell git describe --tags)
   # if VERSION is empty, then populate it with branch's name and raw commit hash
   ifeq (,$(VERSION))
     VERSION := $(BRANCH)-$(COMMIT)


### PR DESCRIPTION
There was a regex match in the makefile to cover the period when we had both text and semver tags. Now we should have only semver, so the regex doesn't match all cases (e.g. suffixes like `-alpha` and `-beta` as @giansalex pointed out).

This removes that to just use the tag. We ought to get this merged ASAP to give us a better version to write up for the uni upgrade instructions.