### PR TITLE
Adding rollback to Juno CLI to workaround AppHash mismatches

### DIFF
--- a/cmd/junod/main.go
+++ b/cmd/junod/main.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/CosmosContracts/juno/app"
 	svrcmd "github.com/cosmos/cosmos-sdk/server/cmd"
+	tmcmds "github.com/tendermint/tendermint/cmd/tendermint/commands"
 	"github.com/tendermint/spm/cosmoscmd"
 )
 
@@ -20,7 +21,7 @@ func main() {
 		// this line is used by starport scaffolding # root/arguments
 		cmdOptions...,
 	)
-
+	rootCmd.AddCommand(tmcmds.RollbackStateCmd)
 	if err := svrcmd.Execute(rootCmd, app.DefaultNodeHome); err != nil {
 		os.Exit(1)
 	}

--- a/cmd/junod/main.go
+++ b/cmd/junod/main.go
@@ -11,6 +11,7 @@ import (
 
 func main() {
 	cmdOptions := GetWasmCmdOptions()
+	cmdOptions = append(cmdOptions, cosmoscmd.AddSubCmd(tmcmds.RollbackStateCmd))
 	rootCmd, _ := cosmoscmd.NewRootCmd(
 		app.Name,
 		app.AccountAddressPrefix,
@@ -21,7 +22,6 @@ func main() {
 		// this line is used by starport scaffolding # root/arguments
 		cmdOptions...,
 	)
-	rootCmd.AddCommand(tmcmds.RollbackStateCmd)
 	if err := svrcmd.Execute(rootCmd, app.DefaultNodeHome); err != nil {
 		os.Exit(1)
 	}


### PR DESCRIPTION
## Background:

During the uni testnet, the upgrade from `v1.0.0` was targetting `v2.0.0-alpha.1`, and shortly thereafter `v2.0.0-alpha.2`.  The upgrade then needed one more fix and many participants were unaware that a `v2.0.0-alpha.3` was prepared.  As such, the normal network upgrade began to splinter into a few variants and seized for about 30 minutes.  Once a sufficient number of validators upgraded to `v2.0.0-alpha.3`, the network resumed producing blocks.

About 20 minutes later, at block 250,489, a wrong `Block.Header.AppHash` began to circulate through a few validators. From the `#validators-testnet` channel on Juno discord:

*siriska*:
https://discord.com/channels/816256689078403103/898335064465743963/904725667353088020

*jabbey*
https://discord.com/channels/816256689078403103/898335064465743963/904731944753954886

*Todd G [ block pane ]*
https://discord.com/channels/816256689078403103/898335064465743963/904760753943359580

The only resolution identified was to `unsafe-reset-all` and resync.  A less impactful method would be to restore from snapshots, which still requires a fair amount of coordination and identification to retrieve.  Given this is a testnet, the offers for snapshots arrived at roughly the same time participants had resynced.

Another alternative would be to simply roll back the offending block and attempt to proceed once more.

## Changes
Add the `rollback` command to the CLI similar to https://github.com/osmosis-labs/osmosis/pull/555/files

```
rollback                 rollback tendermint state by one height
```