### PR TITLE
Add security contact info

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Juno bug reporting and feature requests
+
+The Juno core development team uses GitHub to manage feature requests and bugs. This is done via GitHub Issues.
+
+## Triage and progress 🔜
+
+Issues added to GitHub will be triaged as they come in.
+
+Tracking of in-flight issues will be done through the Juno Core project board, but of course we reserve the right to not make a public issue if there is a security implication in doing so.
+
+## Feature request 🚀
+
+For a feature request, e.g. module inclusion, please make a GitHub issue. Clearly state your use case and what value it will bring to other users or developers on Juno.
+
+If it is something that can be handled by a param change, discuss it on Discord in the `#governance` channel, and consider a governance proposal.
+
+## Standard priority bug 🐛
+
+For a bug that is non-sensitive and/or operational in nature rather than a critical vulnerability, please add it as a GitHub issue.
+
+If it is not triaged in a couple of days, feel free to tag `@the-frey` or `@jakehartnell`.
+
+## Critical bug or security issue 💥
+
+For a critical security bug, please do not publicly disclose it, or post on GitHub. Instead, go to [Discord](https://discord.gg/wHdzjS5vXx), and alert the core engineers:
+
+- Jake (Meow) `Meow Stargaze ✨🔭#1736`
+- Dimi `dimi 🦙#2998`
+- Alex (the-frey) `the-frey#8626`
+- Ben2x4 `Ben2x4#4071`
+- Jacob `jacobgadikian#9883`
+- Giansalex `giansalex#1825`

--- a/readme.md
+++ b/readme.md
@@ -3,24 +3,25 @@
 
 ![c11](https://user-images.githubusercontent.com/79812965/131373443-5ff0d9f6-2e2a-41bd-8347-22ac4983e625.jpg)
 
+❗️For issue disclosure, check out [SECURITY.md](./SECURITY.md) ❗️
 
-Open source platform for interoperable smart contracts which automatically executes, controls or documents a procedure of relevant events and actions 
-according to the terms of such contract or agreement to be valid & usable across multiple sovereign networks.
+Open source platform for inter-operable smart contracts which automatically execute, control or document a procedure of events and actions 
+according to the terms of the contract or agreement to be valid and usable across multiple sovereign networks.
 
-Juno as a **sovereign public blockchain** in the Cosmos ecosystem, aims to provide a sandbox environment for the deployment 
-of such interoperable smart contracts. The network serves as a **decentralized, permissionless & censorship resistant** avenue 
-for developers to efficiently and securely launch application specific smart contracts using proven frameworks 
-and compile them in various languages **Rust & Go** with the potential future addition of C and C++
-Battle tested contract modules such as CosmWasm, will allow for decentralized applications (dapps) to be compiled on robust and secure multi-chain smart contracts.
-EVM support and additional specialized modules to be introduced after genesis subject to onchain governance.
+Juno is a **sovereign public blockchain** in the Cosmos ecosystem. It aims to provide a sandbox environment for the deployment 
+of such inter-operable smart contracts. The network serves as a **decentralized, permissionless, and censorship resistant** zone 
+for developers to efficiently and securely launch application specific smart contracts. Developers can leverage proven frameworks 
+and compile code in various languages, like **Rust & Go** with the potential future addition of C and C++.
+Battle-tested contract modules such as CosmWasm will allow for decentralized applications (dApps) to be compiled as robust and secure multi-chain smart contracts.
+EVM support and additional specialized modules can be introduced after genesis subject to onchain governance.
 
-At the heart of Cosmos is the Inter Blockchain Communication Protocol (IBC), which sets the table for an interoperable base layer 0 
-to now be used to transfer data packets across thousands of independent networks supporting IBC. 
+At the heart of Cosmos is the Inter Blockchain Communication Protocol (IBC), which sets the table for an inter-operable base layer 0 
+that can be used to transfer data packets across thousands of independent networks supporting IBC. 
 Naturally, the next evolutionary milestone is to enable cross-network smart contracts.
 
 The Juno blockchain is built using the **Cosmos SDK framework**. 
-A generalized framework that simplifies the process of building secure blockchain applications on top of Tendermint BFT. 
-It is based on two major principles: Modularity & capabilities-based security.
+Cosmos SDK is a generalized framework that simplifies the process of building secure blockchain applications on top of Tendermint BFT. 
+It is based on two major principles: Modularity and capabilities-based security.
 
 Agreement on the network is reached via **Tendermint BFT consensus**.
 
@@ -28,12 +29,12 @@ Tendermint BFT is a solution that packages the networking and consensus layers o
 allowing developers to focus on application development as opposed to the complex underlying protocol. 
 As a result, Tendermint saves hundreds of hours of development time.
 
-Juno originates from a **community driven initiative**, prompted by developers, validators & delegators in the Cosmos ecosystem.
-The common vision is to preserve the neutrality, performance & reliability of the Cosmos Hub and offload smart contract deployment to a dedicated sister Hub. 
-Juno plans to make an early connection to the Cosmos Hub enabling IBC transfers, cross-chain smart contracts and making use of shared security.
+Juno originates from a **community driven initiative**, prompted by developers, validators and delegators in the Cosmos ecosystem.
+The common vision is to preserve the neutrality, performance, and reliability of the Cosmos Hub. This is achieved by offloading smart contract deployment to a dedicated sister Hub. 
+Juno plans to make an early connection to the Cosmos Hub enabling IBC transfers, cross-chain smart contracts and shared security.
 
-A decentralized launch of the Juno main-net is enabled by a large set of independent validators from across the blockchain space.
-$Juno, the native asset has many functions like securing the Juno Hub & serving as a work token to give access to on-chain governance voting rights 
+A decentralized launch of the Juno main-net was enabled by a large set of independent validators from across the blockchain space.
+$JUNO, the native asset, has many functions like securing the Juno Hub and serving as a work token to give access to on-chain governance voting rights 
 and to provide utility in the deployment and execution of smart contracts.
 
 
@@ -55,7 +56,7 @@ and to provide utility in the deployment and execution of smart contracts.
 
 ⚪️ Highly scalable
 
-⚪️ Ease of use
+⚪️ Ease of use/developer ergonomics
 
 ⚪️ Free & fair asset distribution (100% to staked atom only)
 
@@ -63,10 +64,10 @@ and to provide utility in the deployment and execution of smart contracts.
 
 ⚪️ Balanced governance (Zero top heavy control) 
 
-⚪️ Grass roots community                                               
-                                                     
+⚪️ Grass roots community
+
 ⚪️ Decentralized
-                                             
+
 
 
 
@@ -167,7 +168,7 @@ Once the inflation reaches 10% it gradually reduces on a fixed 1% basis each yea
 JUNO MAX SUPPLY (185.5 Million)
 
 After year 12 the inflation reward schedule ends. 
-Network incentives would primarily come from smart contract usage & regular tx fees generated on the network.
+Network incentives would primarily come from smart contract usage and regular tx fees generated on the network.
 
 
 

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@
 
 ❗️For issue disclosure, check out [SECURITY.md](./SECURITY.md) ❗️
 
-Open source platform for inter-operable smart contracts which automatically execute, control or document a procedure of events and actions 
+**Juno** is an open source platform for inter-operable smart contracts which automatically execute, control or document a procedure of events and actions 
 according to the terms of the contract or agreement to be valid and usable across multiple sovereign networks.
 
 Juno is a **sovereign public blockchain** in the Cosmos ecosystem. It aims to provide a sandbox environment for the deployment 


### PR DESCRIPTION
As per the suggestion of Alex at Confio, suggest a formalised process for features and issue disclosure. 

Now we have a process via the project board, this seems like a logical step to triage and formalise people coming to us.