### PR TITLE
Add compose file and restructure docs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 services:
   node:
     build: .
-    command: ./setup_and_run.sh
+    command: ./setup_and_run.sh juno16g2rahf5846rxzp3fwlswy08fz8ccuwk03k57y
     ports:
       - 1317:1317 # rest
       - 26656:26656 # p2p

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "3"
+services:
+  node:
+    build: .
+    command: ./setup_and_run.sh
+    ports:
+      - 1317:1317 # rest
+      - 26656:26656 # p2p
+      - 26657:26657 # rpc

--- a/docker/setup_and_run.sh
+++ b/docker/setup_and_run.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-./setup_junod.sh
+./setup_junod.sh "$@"
 ./run_junod.sh

--- a/docker/setup_junod.sh
+++ b/docker/setup_junod.sh
@@ -8,29 +8,39 @@ CHAIN_ID=${CHAIN_ID:-testing}
 MONIKER=${MONIKER:-node001}
 KEYRING="--keyring-backend test"
 
-junod init --chain-id "$CHAIN_ID" "$MONIKER"
-# staking/governance token is hardcoded in config, change this
-sed -i "s/\"stake\"/\"$STAKE\"/" "$HOME"/.juno/config/genesis.json
-# this is essential for sub-1s block times (or header times go crazy)
-sed -i 's/"time_iota_ms": "1000"/"time_iota_ms": "10"/' "$HOME"/.juno/config/genesis.json
-# change default keyring-backend to test
-sed -i 's/keyring-backend = "os"/keyring-backend = "test"/' "$HOME"/.juno/config/client.toml
+# check the genesis file
+GENESIS_FILE="$HOME"/.juno/config/genesis.json
+if [ -f "$GENESIS_FILE" ]; then
+  echo "$GENESIS_FILE exists..."
+else
+  echo "$GENESIS_FILE does not exist. Generating..."
 
+  junod init --chain-id "$CHAIN_ID" "$MONIKER"
+  # staking/governance token is hardcoded in config, change this
+  sed -i "s/\"stake\"/\"$STAKE\"/" "$GENESIS_FILE"
+  # this is essential for sub-1s block times (or header times go crazy)
+  sed -i 's/"time_iota_ms": "1000"/"time_iota_ms": "10"/' "$GENESIS_FILE"
+  # change default keyring-backend to test
+  sed -i 's/keyring-backend = "os"/keyring-backend = "test"/' "$HOME"/.juno/config/client.toml
+fi
+
+# are we running for the first time?
 if ! junod keys show validator $KEYRING; then
   (echo "$PASSWORD"; echo "$PASSWORD") | junod keys add validator $KEYRING
+
+  # hardcode the validator account for this instance
+  echo "$PASSWORD" | junod add-genesis-account validator "1000000000$STAKE,1000000000$FEE" $KEYRING
+
+  # (optionally) add a few more genesis accounts
+  for addr in "$@"; do
+    echo $addr
+    junod add-genesis-account "$addr" "1000000000$STAKE,1000000000$FEE"
+  done
+
+  # submit a genesis validator tx
+  ## Workraround for https://github.com/cosmos/cosmos-sdk/issues/8251
+  (echo "$PASSWORD"; echo "$PASSWORD"; echo "$PASSWORD") | junod gentx validator "250000000$STAKE" --chain-id="$CHAIN_ID" --amount="250000000$STAKE" $KEYRING
+  ## should be:
+  # (echo "$PASSWORD"; echo "$PASSWORD"; echo "$PASSWORD") | junod gentx validator "250000000$STAKE" --chain-id="$CHAIN_ID"
+  junod collect-gentxs
 fi
-# hardcode the validator account for this instance
-echo "$PASSWORD" | junod add-genesis-account validator "1000000000$STAKE,1000000000$FEE" $KEYRING
-
-# (optionally) add a few more genesis accounts
-for addr in "$@"; do
-  echo $addr
-  junod add-genesis-account "$addr" "1000000000$STAKE,1000000000$FEE"
-done
-
-# submit a genesis validator tx
-## Workraround for https://github.com/cosmos/cosmos-sdk/issues/8251
-(echo "$PASSWORD"; echo "$PASSWORD"; echo "$PASSWORD") | junod gentx validator "250000000$STAKE" --chain-id="$CHAIN_ID" --amount="250000000$STAKE" $KEYRING
-## should be:
-# (echo "$PASSWORD"; echo "$PASSWORD"; echo "$PASSWORD") | junod gentx validator "250000000$STAKE" --chain-id="$CHAIN_ID"
-junod collect-gentxs

--- a/docker/test-user.env
+++ b/docker/test-user.env
@@ -1,0 +1,2 @@
+TEST_ADDR=juno16g2rahf5846rxzp3fwlswy08fz8ccuwk03k57y
+TEST_MNEMONIC="clip hire initial neck maid actor venue client foam budget lock catalog sweet steak waste crater broccoli pipe steak sister coyote moment obvious choose"

--- a/readme.md
+++ b/readme.md
@@ -187,28 +187,9 @@ Network incentives would primarily come from smart contract usage and regular tx
 
 If you have [Docker](https://www.docker.com/) installed, then you can run a local node with a single command.
 
-This assumes you will connect to it via `junod` from outside the container. You could also use `docker exec`, if you prefer, which eliminates the need to 
-
-1. Open two terminal tabs at the root of this repo.
-2. In tab one, build and run Juno in blocking mode: `./scripts/build_and_run_blocking.sh`. Once it has compiled, you should see blocks appearing.
-
-### Option 1: Using Docker
-
-3. Switch to tab two and exec into the container: `docker exec -it juno-local /bin/sh`
-4. Run `junod status`. You should see JSON status for the Juno node running in Docker.
-
-### Option 2: Using junod (advanced/dev use)
-
-3. Switch to tab two and build juno outside the container if you haven't already: `make build && make install`.
-4. Run `junod status`. You should see JSON status for the Juno node running in Docker.
-
-The RPC port for Juno is forwarded to your host, so as long as Docker is correctly set up, you can send it commands via the Juno binary, `junod` on your host.
-
-Protip: running this script is also a decent sense-check that:
-
-1. The build is still working
-2. The Docker build is still working
-3. The code is in a runnable state
+```bash
+docker-compose up
+```
 
 ## Learn more
 


### PR DESCRIPTION
This:

- Adds a compose file, meaning the local docker build is cached, and exposes all relevant ports
- Changes the setup script so that if it runs inside of an already-built container, already executed parts are skipped
- Instructions are moved out of the readme and into GitBook (I've parked the relevant sections in a change request there until this is merged)
- A couple typos I intro'd to the readme fixed by their removal (lol)

Thanks to @albttx for making me consider the utility of a `docker-compose` file even for a single-service project.

This PR supercedes https://github.com/CosmosContracts/juno/pull/93