### PR TITLE
Fix min-commission upgrade [moneta-beta]

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -718,6 +718,10 @@ func (app *App) RegisterUpgradeHandlers(cfg module.Configurator) {
 		minCommissionRate := sdk.NewDecWithPrec(5, 2)
 		for _, v := range validators {
 			if v.Commission.Rate.LT(minCommissionRate) {
+				if v.Commission.MaxRate.LT(minCommissionRate) {
+					v.Commission.MaxRate = minCommissionRate
+				}
+
 				v.Commission.Rate = minCommissionRate
 				v.Commission.UpdateTime = ctx.BlockHeader().Time
 

--- a/app/app.go
+++ b/app/app.go
@@ -718,12 +718,8 @@ func (app *App) RegisterUpgradeHandlers(cfg module.Configurator) {
 		minCommissionRate := sdk.NewDecWithPrec(5, 2)
 		for _, v := range validators {
 			if v.Commission.Rate.LT(minCommissionRate) {
-				comm, err := app.StakingKeeper.UpdateValidatorCommission(
-					ctx, v, minCommissionRate)
-				if err != nil {
-					panic(err)
-				}
-				v.Commission = comm
+				v.Commission.Rate = minCommissionRate
+				v.Commission.UpdateTime = ctx.BlockHeader().Time
 
 				// call the before-modification hook since we're about to update the commission
 				app.StakingKeeper.BeforeValidatorModified(ctx, v.GetOperator())


### PR DESCRIPTION
Skip validations:
- max change rate:
- new rate cannot be changed more than once within 24 hours