### PR TITLE
Roll moneta-alpha and moneta-beta into a single upgrade handler

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -705,11 +705,7 @@ func (app *App) RegisterTendermintService(clientCtx client.Context) {
 
 // RegisterUpgradeHandlers returns upgrade handlers
 func (app *App) RegisterUpgradeHandlers(cfg module.Configurator) {
-	app.UpgradeKeeper.SetUpgradeHandler("moneta-alpha", func(ctx sdk.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
-		return app.mm.RunMigrations(ctx, cfg, vm)
-	})
-
-	app.UpgradeKeeper.SetUpgradeHandler("moneta-beta", func(ctx sdk.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+	app.UpgradeKeeper.SetUpgradeHandler("moneta", func(ctx sdk.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
 		// force an update of validator min commission
 		validators := app.StakingKeeper.GetAllValidators(ctx)
 		// hard code this because we don't want


### PR DESCRIPTION
As `moneta-alpha` required a no-op handler, I _think_ this might be all that is needed to merge `-alpha` and `-beta` into a single handler. We should probably not merge this yet though until we're 100% on how we should test it. I'm sort of erring towards relaunching `uni` at the moment.