### PR TITLE
Add release trigger to docker build.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,6 +37,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
+            type=semver,pattern={{raw}}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
       - name: Build and push

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,10 @@ name: ci
 
 on:
   pull_request:
+  release:
+    types: [published, created, edited]
   push:
+    tags:
     branches:
       - 'main'
 


### PR DESCRIPTION
Second try at #98 

TL;DR the other PR added PRs and tags, but we use the GitHub UI to tag releases. These are not considered tags, but ... you guessed it, releases. So the other PR will only pick up tags on a push event.

Note that although this adds releases, these are not prereleases, only `[published, created, edited]` events. One of the event types available is `prereleased`, so I don't know if we want that as well? Thoughts?