### PR TITLE
10x the wasm compile cost in config

### DIFF
--- a/app/wasm_config.go
+++ b/app/wasm_config.go
@@ -8,7 +8,7 @@ const (
 	// DefaultJunoInstanceCost is initially set the same as in wasmd
 	DefaultJunoInstanceCost uint64 = 60_000
 	// DefaultJunoCompileCost set to a large number for testing
-	DefaultJunoCompileCost uint64 = 10
+	DefaultJunoCompileCost uint64 = 100
 )
 
 // JunoGasRegisterConfig is defaults plus a custom compile amount


### PR DESCRIPTION
Should do what it says on the tin.

As discussed on TG, so we can quickly test on uni/astarte before signing off moneta release.