### PR TITLE
Add moneta-patch base upgrade handler

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -734,6 +734,10 @@ func (app *App) RegisterUpgradeHandlers(cfg module.Configurator) {
 		}
 		return app.mm.RunMigrations(ctx, cfg, vm)
 	})
+
+	app.UpgradeKeeper.SetUpgradeHandler("moneta-patch", func(ctx sdk.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+		return app.mm.RunMigrations(ctx, cfg, vm)
+	})
 }
 
 // GetMaccPerms returns a copy of the module account permissions

--- a/app/app.go
+++ b/app/app.go
@@ -710,31 +710,6 @@ func (app *App) RegisterTendermintService(clientCtx client.Context) {
 
 // RegisterUpgradeHandlers returns upgrade handlers
 func (app *App) RegisterUpgradeHandlers(cfg module.Configurator) {
-	app.UpgradeKeeper.SetUpgradeHandler("moneta", func(ctx sdk.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
-		// force an update of validator min commission
-		validators := app.StakingKeeper.GetAllValidators(ctx)
-		// hard code this because we don't want
-		// a) a fork or
-		// b) immediate reaction with additional gov props
-		minCommissionRate := sdk.NewDecWithPrec(5, 2)
-		for _, v := range validators {
-			if v.Commission.Rate.LT(minCommissionRate) {
-				if v.Commission.MaxRate.LT(minCommissionRate) {
-					v.Commission.MaxRate = minCommissionRate
-				}
-
-				v.Commission.Rate = minCommissionRate
-				v.Commission.UpdateTime = ctx.BlockHeader().Time
-
-				// call the before-modification hook since we're about to update the commission
-				app.StakingKeeper.BeforeValidatorModified(ctx, v.GetOperator())
-
-				app.StakingKeeper.SetValidator(ctx, v)
-			}
-		}
-		return app.mm.RunMigrations(ctx, cfg, vm)
-	})
-
 	app.UpgradeKeeper.SetUpgradeHandler("moneta-patch", func(ctx sdk.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
 		return app.mm.RunMigrations(ctx, cfg, vm)
 	})


### PR DESCRIPTION
A basic upgrade handler for `moneta-patch` - if there are migrations required to e.g. try and change existing contract addresses then we will need to change this.

Second question - we can remove the `moneta` upgrade handler now, right?