### PR TITLE
Add edge pr tag and CW test harness

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,6 +37,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
+            type=edge, event=pr
             type=semver,pattern={{raw}}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,7 +37,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=edge, event=pr
+            type=raw,value=pr-latest,event=pr
             type=semver,pattern={{raw}}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,30 @@
+name: contract-ci
+
+on:
+  pull_request:
+  push:
+    tags:
+    branches:
+      - 'main'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Docker compose
+        run: GAS_LIMIT="-1" STAKE_TOKEN="ujunox" docker-compose up -d
+      - name: Sleep
+        uses: jakejarvis/wait-action@master
+        with:
+          time: '60s'
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          repository: 'envoylabs/whoami'
+          ref: 'v0.4.3'
+      - name: Run deploy script
+        run: |
+          chmod a+x ./scripts/deploy_ci.sh
+          ./scripts/deploy_ci.sh juno16g2rahf5846rxzp3fwlswy08fz8ccuwk03k57y
+

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Docker compose
-        run: GAS_LIMIT="-1" STAKE_TOKEN="ujunox" docker-compose up -d
+        run: STAKE_TOKEN="ujunox" docker-compose up -d
       - name: Sleep
         uses: jakejarvis/wait-action@master
         with:
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: 'envoylabs/whoami'
-          ref: 'v0.4.3'
+          ref: 'v0.4.4'
       - name: Run deploy script
         run: |
           chmod a+x ./scripts/deploy_ci.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,6 @@ services:
       - 1317:1317 # rest
       - 26656:26656 # p2p
       - 26657:26657 # rpc
+    environment:
+      - GAS_LIMIT=${GAS_LIMIT:-100000000}
+      - STAKE_TOKEN=${STAKE_TOKEN:-ustake}

--- a/docker/setup_junod.sh
+++ b/docker/setup_junod.sh
@@ -7,7 +7,9 @@ FEE=${FEE_TOKEN:-ucosm}
 CHAIN_ID=${CHAIN_ID:-testing}
 MONIKER=${MONIKER:-node001}
 KEYRING="--keyring-backend test"
-BLOCK_GAS_LIMIT=100000000 # should mirror mainnet
+BLOCK_GAS_LIMIT=${GAS_LIMIT:-100000000} # should mirror mainnet
+
+echo "Configured Block Gas Limit: $BLOCK_GAS_LIMIT"
 
 # check the genesis file
 GENESIS_FILE="$HOME"/.juno/config/genesis.json


### PR DESCRIPTION
Deploy a contract as part of the CI harness.

Currently uses `whoami` as DAODAO is private, and changes to various scripts were needed.