### PR TITLE
tooling: spike binary release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+on: 
+  release:
+    types: [created]
+
+jobs:
+  release-alpine-static:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Docker compose
+        run: STAKE_TOKEN="ujunox" docker-compose up -d
+      - name: Copy binary
+        run: docker cp juno_node_1:/usr/bin/junod ./junod
+      - name: Get release
+        id: get_release
+        uses: bruceadams/get-release@v1.2.3
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+      - name: Upload release binary
+        uses: actions/upload-release-asset@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          asset_path: ./junod
+          asset_name: junod
+          asset_content_type: application/octet-stream


### PR DESCRIPTION
Closes #107 but will likely require a bit of fiddling.

This can't be properly tested until post-merge, unfortunately. I think it's going to be a bit of a pain to get right