### PR TITLE
Add name to upload binary step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,6 @@
-on: 
+name: release binary
+
+on:
   release:
     types: [created]
 


### PR DESCRIPTION
~Okay, so didn't look like the last one ran when I coined a release. Trying to work out why now.~

EDIT 1: Huh, apparently it _did_, it just didn't show a damn thing in the UI.

EDIT 2: Okay, it worked and the binary seems to work on a linux machine I just threw it on. Interesting. The step still needs naming however. I think the lack of name might be why it's not showing in the UI, as it shows on this PR _once you've given it a name_.

~Have set this to build on PR just so I can see what is going on.~