### PR TITLE
Bump to wasmd 0.23.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/CosmosContracts/juno
 go 1.17
 
 require (
-	github.com/CosmWasm/wasmd v0.22.0
+	github.com/CosmWasm/wasmd v0.23.0
 	github.com/cosmos/cosmos-sdk v0.45.0
 	github.com/cosmos/ibc-go/v2 v2.0.2
 	github.com/gogo/protobuf v1.3.3

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,8 @@ github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d h1:nalkkPQ
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d/go.mod h1:URdX5+vg25ts3aCh8H5IFZybJYKWhJHYMTnf+ULtoC4=
 github.com/CosmWasm/wasmd v0.22.0 h1:6Bn2DDjHvLwZJkYXL+/PRQ9bSll0ReX2IZqRt/BQkhg=
 github.com/CosmWasm/wasmd v0.22.0/go.mod h1:kNDnMAQDJyVek9k6SxCNijMCzOROzzUGBRT8r/vr7oY=
+github.com/CosmWasm/wasmd v0.23.0 h1:yOksa/TORt2BtXjUKKqcJ67d6O+Jv2Y6wT1Ekm1Como=
+github.com/CosmWasm/wasmd v0.23.0/go.mod h1:kNDnMAQDJyVek9k6SxCNijMCzOROzzUGBRT8r/vr7oY=
 github.com/CosmWasm/wasmvm v1.0.0-beta4 h1:cw77olxPPIktnbZll7V3Dp+ARxrdqLvsiPqaNjaZ/BM=
 github.com/CosmWasm/wasmvm v1.0.0-beta4/go.mod h1:mtwKxbmsko1zdwpaKiRkRwxijMmIAtnLaX5/UT2nPFk=
 github.com/CosmWasm/wasmvm v1.0.0-beta5 h1:38M8z89LB5cFMYB5vfjewMzz9Pr8TB1QBHdjnrWnkas=


### PR DESCRIPTION
They've released a quick version 'cos some things were missed. We should be able to just use this with the upgrade handler we just merged - and we've not officially tagged a release yet, so no biggie.

I've told uni validators that we will be testing the upgrade hopefully next Tuesday or Weds, so should have more than enough time to get this in :)