### PR TITLE
Add local CORS config flag

### DIFF
--- a/docker/setup_junod.sh
+++ b/docker/setup_junod.sh
@@ -29,6 +29,16 @@ else
   sed -i 's/keyring-backend = "os"/keyring-backend = "test"/' "$HOME"/.juno/config/client.toml
 fi
 
+echo "Unsafe CORS value: $UNSAFE_CORS"
+
+APP_TOML_CONFIG="$HOME"/.juno/config/app.toml
+CONFIG_TOML_CONFIG="$HOME"/.juno/config/config.toml
+if [ -n $UNSAFE_CORS ]; then
+  echo "Unsafe CORS set... updating app.toml and config.toml"
+  sed -i "s/enabled-unsafe-cors = false/enabled-unsafe-cors = true/" "$APP_TOML_CONFIG"
+  sed -i "s/cors_allowed_origins = \[\]/cors_allowed_origins = \[\"\*\"\]/" "$CONFIG_TOML_CONFIG"
+fi
+
 # are we running for the first time?
 if ! junod keys show validator $KEYRING; then
   (echo "$PASSWORD"; echo "$PASSWORD") | junod keys add validator $KEYRING


### PR DESCRIPTION
Fixes #162

This adds a configuration option for local docker development, `UNSAFE_CORS=true` which will update `app.toml` and `config.toml` for the app that is bootstrapped. This removes the need for devs to manually adopt workarounds in their own applications and makes the dev experience more ergonomic for newcomers.

The issue was raised after being reported several times by new devs in the community.