### PR TITLE
Add lupercalia beta handler to allow for testnet upgrade

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -779,6 +779,10 @@ func (app *App) RegisterUpgradeHandlers(cfg module.Configurator) {
 		}
 		return app.mm.RunMigrations(ctx, cfg, vm)
 	})
+
+	app.UpgradeKeeper.SetUpgradeHandler("lupercalia-beta", func(ctx sdk.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+		return app.mm.RunMigrations(ctx, cfg, vm)
+	})
 }
 
 // GetMaccPerms returns a copy of the module account permissions


### PR DESCRIPTION
This _should not be merged_. 

It is set as a draft PR purely so:

- changes are clear
- docker container will be built
- very obvious what the git tag refers to

This handler allows us to run a second upgrade on `uni-2` to test the additional things we want to sneak into lupercalia.