### PR TITLE
Update README to reflect v2.3.0 quickstart cmd

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -170,17 +170,6 @@ JUNO MAX SUPPLY (185.5 Million)
 After year 12 the inflation reward schedule ends. 
 Network incentives would primarily come from smart contract usage and regular tx fees generated on the network.
 
-
-
-
-
-
-
-
-
-
-
-
 **Juno** is a blockchain built using Cosmos SDK and Tendermint and created with [Starport](https://github.com/tendermint/starport).
 
 ## Get started
@@ -188,7 +177,7 @@ Network incentives would primarily come from smart contract usage and regular tx
 If you have [Docker](https://www.docker.com/) installed, then you can run a local node with a single command.
 
 ```bash
-docker-compose up
+STAKE_TOKEN=ujunox UNSAFE_CORS=true docker-compose up
 ```
 
 ## Learn more


### PR DESCRIPTION
Just noticed the quickstart is out of date, so updated with the current docker-compose cmd.