### PR TITLE
Attempt to fix local REST server issues

### DIFF
--- a/docker/setup_junod.sh
+++ b/docker/setup_junod.sh
@@ -30,9 +30,14 @@ else
 fi
 
 APP_TOML_CONFIG="$HOME"/.juno/config/app.toml
+APP_TOML_CONFIG_NEW="$HOME"/.juno/config/app_new.toml
 CONFIG_TOML_CONFIG="$HOME"/.juno/config/config.toml
 if [ -n $UNSAFE_CORS ]; then
   echo "Unsafe CORS set... updating app.toml and config.toml"
+  # sorry about this bit, but toml is rubbish for structural editing
+  sed -n '1h;1!H;${g;s/# Enable defines if the API server should be enabled.\nenable = false/enable = true/;p;}' "$APP_TOML_CONFIG" > "$APP_TOML_CONFIG_NEW"
+  mv "$APP_TOML_CONFIG_NEW" "$APP_TOML_CONFIG"
+  # ...and breathe
   sed -i "s/enabled-unsafe-cors = false/enabled-unsafe-cors = true/" "$APP_TOML_CONFIG"
   sed -i "s/cors_allowed_origins = \[\]/cors_allowed_origins = \[\"\*\"\]/" "$CONFIG_TOML_CONFIG"
 fi


### PR DESCRIPTION
Some users have reported Keplr issues even with `no-legacy-stdTx` set, and our team has encountered the same. It looks like it's simply a case of needing the REST server enabled, so makes sense to bundle it in with CORS config.

This PR is a placeholder so a container gets built that I can test locally.