### PR TITLE
Revert "Merge pull request #80"

### DIFF
--- a/cmd/junod/main.go
+++ b/cmd/junod/main.go
@@ -6,12 +6,10 @@ import (
 	"github.com/CosmosContracts/juno/app"
 	svrcmd "github.com/cosmos/cosmos-sdk/server/cmd"
 	"github.com/tendermint/starport/starport/pkg/cosmoscmd"
-	tmcmds "github.com/tendermint/tendermint/cmd/tendermint/commands"
 )
 
 func main() {
 	cmdOptions := GetWasmCmdOptions()
-	cmdOptions = append(cmdOptions, cosmoscmd.AddSubCmd(tmcmds.RollbackStateCmd))
 	rootCmd, _ := cosmoscmd.NewRootCmd(
 		app.Name,
 		app.AccountAddressPrefix,
@@ -22,6 +20,7 @@ func main() {
 		// this line is used by starport scaffolding # root/arguments
 		cmdOptions...,
 	)
+
 	if err := svrcmd.Execute(rootCmd, app.DefaultNodeHome); err != nil {
 		os.Exit(1)
 	}


### PR DESCRIPTION
This reverts commit e07087055b903aa721596f9e4928780ab8e34a7f.

cosmos-sdk 0.45.2 introduces a _rollback command_ which includes tendermint rollback.

Currently, junod v6.0.0 has 2 rollback cmd
```
  rollback                 rollback cosmos-sdk and tendermint state by one height
  rollback                 rollback tendermint state by one height
```