### PR TITLE
Rename build steps and spike unity prop and gov/sudo testing CI step

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -1,0 +1,26 @@
+name: Build Docker Image on PR
+
+on:
+  pull_request:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Build without push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64
+          push: false
+          build-args: arch=x86_64

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,4 @@
-name: ci
+name: Build and Push Docker Image
 
 on:
   workflow_dispatch:

--- a/.github/workflows/gov.yml
+++ b/.github/workflows/gov.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: 'CosmosContracts/cw-unity-prop'
-          ref: 'v0.3.1'
+          ref: 'v0.3.2'
       - name: Run deploy script
         run: |
           chmod a+x ./scripts/deploy_ci.sh

--- a/.github/workflows/gov.yml
+++ b/.github/workflows/gov.yml
@@ -22,9 +22,9 @@ jobs:
       - name: Run deploy script
         run: |
           chmod a+x ./scripts/deploy_ci.sh
-          ./scripts/deploy.sh juno16g2rahf5846rxzp3fwlswy08fz8ccuwk03k57y
+          ./scripts/deploy_ci.sh juno16g2rahf5846rxzp3fwlswy08fz8ccuwk03k57y
       - name: Test gov prop
         run: |
           chmod a+x ./scripts/submit_gov_ci.sh
-          ./scripts/submit_gov.sh juno16g2rahf5846rxzp3fwlswy08fz8ccuwk03k57y
+          ./scripts/submit_gov_ci.sh juno16g2rahf5846rxzp3fwlswy08fz8ccuwk03k57y
 

--- a/.github/workflows/gov.yml
+++ b/.github/workflows/gov.yml
@@ -1,0 +1,30 @@
+name: Gov Contract CI
+
+on:
+  pull_request:
+  push:
+    tags:
+    branches:
+      - 'main'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Docker compose
+        run: STAKE_TOKEN="ujunox" docker-compose up -d
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          repository: 'CosmosContracts/cw-unity-prop'
+          ref: 'v0.3.0'
+      - name: Run deploy script
+        run: |
+          chmod a+x ./scripts/deploy.sh
+          ./scripts/deploy.sh juno16g2rahf5846rxzp3fwlswy08fz8ccuwk03k57y
+      - name: Test gov prop
+        run: |
+          chmod a+x ./scripts/submit_gov.sh
+          ./scripts/submit_gov.sh juno16g2rahf5846rxzp3fwlswy08fz8ccuwk03k57y
+

--- a/.github/workflows/gov.yml
+++ b/.github/workflows/gov.yml
@@ -18,13 +18,13 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: 'CosmosContracts/cw-unity-prop'
-          ref: 'v0.3.0'
+          ref: 'v0.3.1'
       - name: Run deploy script
         run: |
-          chmod a+x ./scripts/deploy.sh
+          chmod a+x ./scripts/deploy_ci.sh
           ./scripts/deploy.sh juno16g2rahf5846rxzp3fwlswy08fz8ccuwk03k57y
       - name: Test gov prop
         run: |
-          chmod a+x ./scripts/submit_gov.sh
+          chmod a+x ./scripts/submit_gov_ci.sh
           ./scripts/submit_gov.sh juno16g2rahf5846rxzp3fwlswy08fz8ccuwk03k57y
 

--- a/.github/workflows/gov_deploy.yml
+++ b/.github/workflows/gov_deploy.yml
@@ -1,4 +1,4 @@
-name: Gov Contract CI
+name: Gov Contract CI - Deploy
 
 on:
   pull_request:
@@ -19,12 +19,8 @@ jobs:
         with:
           repository: 'CosmosContracts/cw-unity-prop'
           ref: 'v0.3.2'
-      - name: Run deploy script
+      - name: Test gov deploy
         run: |
           chmod a+x ./scripts/deploy_ci.sh
           ./scripts/deploy_ci.sh juno16g2rahf5846rxzp3fwlswy08fz8ccuwk03k57y
-      - name: Test gov prop
-        run: |
-          chmod a+x ./scripts/submit_gov_ci.sh
-          ./scripts/submit_gov_ci.sh juno16g2rahf5846rxzp3fwlswy08fz8ccuwk03k57y
 

--- a/.github/workflows/gov_submit.yml
+++ b/.github/workflows/gov_submit.yml
@@ -1,0 +1,26 @@
+name: Gov Contract CI - Submit Contract Prop
+
+on:
+  pull_request:
+  push:
+    tags:
+    branches:
+      - 'main'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Docker compose
+        run: STAKE_TOKEN="ujunox" docker-compose up -d
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          repository: 'CosmosContracts/cw-unity-prop'
+          ref: 'v0.3.2'
+      - name: Test smart contract gov prop
+        run: |
+          chmod a+x ./scripts/submit_gov_ci.sh
+          ./scripts/submit_gov_ci.sh juno16g2rahf5846rxzp3fwlswy08fz8ccuwk03k57y
+

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,4 +1,4 @@
-name: contract-ci
+name: Contract CI
 
 on:
   pull_request:


### PR DESCRIPTION
This:

- Updates the names of a bunch of CI so it's clearer what it does
- Adds a unity contract CI runner to ensure there are no regressions
- Adds a unity contract governance action to ensure there are no regressions in Juno gov routing to contracts
- Adds a separate docker build _but not push_ step for PRs only (to sense check builds succeed)

