### PR TITLE
fix: reinstate pushing docker build on tags/release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,7 +1,6 @@
 name: Build and Push Docker Image
 
 on:
-  workflow_dispatch:
   release:
     types: [published, created, edited]
   push:


### PR DESCRIPTION
#217 appears to have broken the build pipeline on tags.  Investigating here.