### PR TITLE
Add store types

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/server/api"
 	"github.com/cosmos/cosmos-sdk/server/config"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
+	store "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	"github.com/cosmos/cosmos-sdk/version"
@@ -635,6 +636,19 @@ func New(
 		if err != nil {
 			panic("failed to register snapshot extension: " + err.Error())
 		}
+	}
+
+	upgradeInfo, err := app.UpgradeKeeper.ReadUpgradeInfoFromDisk()
+	if err != nil {
+		panic(err)
+	}
+
+	if upgradeInfo.Name == "multiverse" && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
+		storeUpgrades := store.StoreUpgrades{
+			Added: []string{icacontrollertypes.StoreKey, icahosttypes.StoreKey},
+		}
+
+		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
 	}
 
 	if loadLatest {


### PR DESCRIPTION
As per the IBC go docs https://github.com/cosmos/ibc-go/blob/main/docs/migrations/v2-to-v3.md

I think I missed these in the enabling IBC Host PR, which means we _may_ need this to stop uni falling over.

If I'm wrong, let me know.