### PR TITLE
Add dump docker (on failure) to CI

### DIFF
--- a/.github/workflows/gov_deploy.yml
+++ b/.github/workflows/gov_deploy.yml
@@ -23,4 +23,7 @@ jobs:
         run: |
           chmod a+x ./scripts/deploy_ci.sh
           ./scripts/deploy_ci.sh juno16g2rahf5846rxzp3fwlswy08fz8ccuwk03k57y
+      - name: Dump docker logs on failure
+        if: failure()
+        uses: jwalton/gh-docker-logs@v1
 

--- a/.github/workflows/gov_submit.yml
+++ b/.github/workflows/gov_submit.yml
@@ -23,4 +23,7 @@ jobs:
         run: |
           chmod a+x ./scripts/submit_gov_ci.sh
           ./scripts/submit_gov_ci.sh juno16g2rahf5846rxzp3fwlswy08fz8ccuwk03k57y
+      - name: Dump docker logs on failure
+        if: failure()
+        uses: jwalton/gh-docker-logs@v1
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -23,4 +23,7 @@ jobs:
         run: |
           chmod a+x ./scripts/deploy_ci.sh
           ./scripts/deploy_ci.sh
+      - name: Dump docker logs on failure
+        if: failure()
+        uses: jwalton/gh-docker-logs@v1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,3 +27,6 @@ jobs:
           asset_path: ./junod
           asset_name: junod
           asset_content_type: application/octet-stream
+      - name: Dump docker logs on failure
+        if: failure()
+        uses: jwalton/gh-docker-logs@v1


### PR DESCRIPTION
Looks like the diagnosis of #207 could have gone much faster if we had the logs... trying 

https://github.com/jwalton/gh-docker-logs

(Re-introduced the failure to test)

@faddat I bet this would have saved quite a bit of time:

<img width="644" alt="image" src="https://user-images.githubusercontent.com/759747/173367019-16b89e22-7332-4e50-bcda-87bd521bab3d.png">
