### PR TITLE
Add ICA ModuleBasic

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -199,6 +199,7 @@ var (
 		authzmodule.AppModuleBasic{},
 		// this line is used by starport scaffolding # stargate/app/moduleBasic
 		wasm.AppModuleBasic{},
+		ica.AppModuleBasic{},
 	)
 
 	// module account permissions


### PR DESCRIPTION
- Fix `junod init ...` does not add `interchainaccounts` section to genesis
- Add to cli `junod q interchain-accounts`
