### PR TITLE
docker compose now denominates the STAKE_TOKEN in ujunox

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,4 +12,4 @@ services:
       - 26657:26657 # rpc
     environment:
       - GAS_LIMIT=${GAS_LIMIT:-100000000}
-      - STAKE_TOKEN=${STAKE_TOKEN:-ustake}
+      - STAKE_TOKEN=${STAKE_TOKEN:-ujunox}


### PR DESCRIPTION
To harmonize the `docker run` and `docker compose` approaches as well as to stay consistent with the "CosmWasm by Dummies"  series.