### PR TITLE
go 1.19

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.19
       - run: go build ./...
 
   test:
@@ -20,7 +20,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.19
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Test
@@ -36,7 +36,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.19
       - run: |
           go mod tidy
           CHANGES_IN_REPO=$(git status --porcelain)

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # docker build . -t cosmoscontracts/juno:latest
 # docker run --rm -it cosmoscontracts/juno:latest /bin/sh
-FROM golang:1.18-alpine3.15 AS go-builder
+FROM golang:1.19-alpine3.15 AS go-builder
 
 # this comes from standard alpine nightly file
 #  https://github.com/rust-lang/docker-rust-nightly/blob/master/alpine3.12/Dockerfile

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/CosmosContracts/juno/v10
 
-go 1.18
+go 1.19
 
 require (
 	github.com/CosmWasm/wasmd v0.28.0


### PR DESCRIPTION
Go 1.19 contains some improvements to the crypto libraries that enhance safety.  I think it makes sense for us to be early adopters. 

https://tip.golang.org/doc/go1.19