### PR TITLE
Fix: Docker builds x ICA genesis state

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,8 @@ COPY . /code/
 # See https://github.com/CosmWasm/wasmvm/releases
 ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.1.0/libwasmvm_muslc.aarch64.a /lib/libwasmvm_muslc.aarch64.a
 ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.1.0/libwasmvm_muslc.x86_64.a /lib/libwasmvm_muslc.x86_64.a
-RUN sha256sum /lib/libwasmvm_muslc.aarch64.a | grep 7d2239e9f25e96d0d4daba982ce92367aacf0cbd95d2facb8442268f2b1cc1fc
-RUN sha256sum /lib/libwasmvm_muslc.x86_64.a | grep f6282df732a13dec836cda1f399dd874b1e3163504dbd9607c6af915b2740479
+RUN sha256sum /lib/libwasmvm_muslc.aarch64.a | grep 728993b91b35037ae8d9933c3a9ee018e49a7926571ce4109f55d9954efcbe9a
+RUN sha256sum /lib/libwasmvm_muslc.x86_64.a | grep d06607db7bda6d3981f0717133584dd5480a6bca7b1e208b4526e68f3ccf3b31
 
 # Copy the library you want to the final location that will be found by the linker flag `-lwasmvm_muslc`
 RUN cp "/lib/libwasmvm_muslc.$(uname -m).a" /lib/libwasmvm_muslc.a

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,8 @@ WORKDIR /code
 COPY . /code/
 
 # See https://github.com/CosmWasm/wasmvm/releases
-ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.0.0/libwasmvm_muslc.aarch64.a /lib/libwasmvm_muslc.aarch64.a
-ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.0.0/libwasmvm_muslc.x86_64.a /lib/libwasmvm_muslc.x86_64.a
+ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.1.0/libwasmvm_muslc.aarch64.a /lib/libwasmvm_muslc.aarch64.a
+ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.1.0/libwasmvm_muslc.x86_64.a /lib/libwasmvm_muslc.x86_64.a
 RUN sha256sum /lib/libwasmvm_muslc.aarch64.a | grep 7d2239e9f25e96d0d4daba982ce92367aacf0cbd95d2facb8442268f2b1cc1fc
 RUN sha256sum /lib/libwasmvm_muslc.x86_64.a | grep f6282df732a13dec836cda1f399dd874b1e3163504dbd9607c6af915b2740479
 

--- a/app/app.go
+++ b/app/app.go
@@ -455,7 +455,7 @@ func New(
 
 	// The last arguments can contain custom message handlers, and custom query handlers,
 	// if we want to allow any custom callbacks
-	supportedFeatures := "iterator,staking,stargate"
+	supportedFeatures := "iterator,staking,stargate,cosmwasm_1_1"
 	app.wasmKeeper = wasm.NewKeeper(
 		appCodec,
 		keys[wasm.StoreKey],

--- a/cmd/junod/genica.go
+++ b/cmd/junod/genica.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/spf13/cobra"
+
+	icacontrollertypes "github.com/cosmos/ibc-go/v3/modules/apps/27-interchain-accounts/controller/types"
+	icahosttypes "github.com/cosmos/ibc-go/v3/modules/apps/27-interchain-accounts/host/types"
+	icatypes "github.com/cosmos/ibc-go/v3/modules/apps/27-interchain-accounts/types"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/server"
+	"github.com/cosmos/cosmos-sdk/x/genutil"
+	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
+)
+
+// AddGenesisAccountCmd returns add-genesis-account cobra Command.
+func AddGenesisIcaCmd(defaultNodeHome string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "add-ica-config",
+		Short: "Add ICA config to genesis.json",
+		Long:  `Add default ICA configuration to genesis.json`,
+		Args:  cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx := client.GetClientContextFromCmd(cmd)
+			serverCtx := server.GetServerContextFromCmd(cmd)
+			config := serverCtx.Config
+
+			config.SetRoot(clientCtx.HomeDir)
+
+			genFile := config.GenesisFile()
+			appState, genDoc, err := genutiltypes.GenesisStateFromGenFile(genFile)
+			if err != nil {
+				return fmt.Errorf("failed to unmarshal genesis state: %w", err)
+			}
+
+			controllerGenesisState := icatypes.DefaultControllerGenesis()
+			// no params set in upgrade handler, no params set here
+			controllerGenesisState.Params = icacontrollertypes.Params{}
+
+			hostGenesisState := icatypes.DefaultHostGenesis()
+			// add the messages we want
+			hostGenesisState.Params = icahosttypes.Params{
+				HostEnabled: true,
+				AllowMessages: []string{
+					"/cosmos.bank.v1beta1.MsgSend",
+					"/cosmos.staking.v1beta1.MsgDelegate",
+					"/cosmos.staking.v1beta1.MsgBeginRedelegate",
+					"/cosmos.staking.v1beta1.MsgCreateValidator",
+					"/cosmos.staking.v1beta1.MsgEditValidator",
+					"/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward",
+					"/cosmos.distribution.v1beta1.MsgSetWithdrawAddress",
+					"/cosmos.distribution.v1beta1.MsgWithdrawValidatorCommission",
+					"/cosmos.distribution.v1beta1.MsgFundCommunityPool",
+					"/cosmos.gov.v1beta1.MsgVote",
+					"/cosmos.authz.v1beta1.MsgExec",
+					"/cosmos.authz.v1beta1.MsgGrant",
+					"/cosmos.authz.v1beta1.MsgRevoke",
+					"/cosmwasm.wasm.v1.MsgStoreCode",
+					"/cosmwasm.wasm.v1.MsgInstantiateContract",
+					"/cosmwasm.wasm.v1.MsgExecuteContract",
+				},
+			}
+
+			newIcaGenState := icatypes.NewGenesisState(controllerGenesisState, hostGenesisState)
+
+			icaGenStateBz, err := clientCtx.Codec.MarshalJSON(newIcaGenState)
+			if err != nil {
+				return fmt.Errorf("failed to marshal auth genesis state: %w", err)
+			}
+
+			appState[icatypes.ModuleName] = icaGenStateBz
+
+			appStateJSON, err := json.Marshal(appState)
+			if err != nil {
+				return fmt.Errorf("failed to marshal application genesis state: %w", err)
+			}
+
+			genDoc.AppState = appStateJSON
+			return genutil.ExportGenesisFile(genDoc, genFile)
+		},
+	}
+
+	cmd.Flags().String(flags.FlagHome, defaultNodeHome, "The application home directory")
+	cmd.Flags().String(flags.FlagKeyringBackend, flags.DefaultKeyringBackend, "Select keyring's backend (os|file|kwallet|pass|test)")
+
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}

--- a/cmd/junod/genica.go
+++ b/cmd/junod/genica.go
@@ -46,7 +46,6 @@ func AddGenesisIcaCmd(defaultNodeHome string) *cobra.Command {
 				HostEnabled: true,
 				AllowMessages: []string{
 					"/cosmos.bank.v1beta1.MsgSend",
-					"/cosmos.bank.v1beta1.MsgMultiSend",
 					"/cosmos.staking.v1beta1.MsgDelegate",
 					"/cosmos.staking.v1beta1.MsgUndelegate",
 					"/cosmos.staking.v1beta1.MsgBeginRedelegate",
@@ -57,6 +56,7 @@ func AddGenesisIcaCmd(defaultNodeHome string) *cobra.Command {
 					"/cosmos.distribution.v1beta1.MsgWithdrawValidatorCommission",
 					"/cosmos.distribution.v1beta1.MsgFundCommunityPool",
 					"/cosmos.gov.v1beta1.MsgVote",
+					"/cosmos.gov.v1beta1.MsgVoteWeighted",
 					"/cosmos.authz.v1beta1.MsgExec",
 					"/cosmos.authz.v1beta1.MsgGrant",
 					"/cosmos.authz.v1beta1.MsgRevoke",

--- a/cmd/junod/genica.go
+++ b/cmd/junod/genica.go
@@ -47,6 +47,7 @@ func AddGenesisIcaCmd(defaultNodeHome string) *cobra.Command {
 				AllowMessages: []string{
 					"/cosmos.bank.v1beta1.MsgSend",
 					"/cosmos.staking.v1beta1.MsgDelegate",
+					"/cosmos.staking.v1beta1.MsgUndelegate",
 					"/cosmos.staking.v1beta1.MsgBeginRedelegate",
 					"/cosmos.staking.v1beta1.MsgCreateValidator",
 					"/cosmos.staking.v1beta1.MsgEditValidator",

--- a/cmd/junod/genica.go
+++ b/cmd/junod/genica.go
@@ -46,6 +46,7 @@ func AddGenesisIcaCmd(defaultNodeHome string) *cobra.Command {
 				HostEnabled: true,
 				AllowMessages: []string{
 					"/cosmos.bank.v1beta1.MsgSend",
+					"/cosmos.bank.v1beta1.MsgMultiSend",
 					"/cosmos.staking.v1beta1.MsgDelegate",
 					"/cosmos.staking.v1beta1.MsgUndelegate",
 					"/cosmos.staking.v1beta1.MsgBeginRedelegate",
@@ -62,6 +63,7 @@ func AddGenesisIcaCmd(defaultNodeHome string) *cobra.Command {
 					"/cosmwasm.wasm.v1.MsgStoreCode",
 					"/cosmwasm.wasm.v1.MsgInstantiateContract",
 					"/cosmwasm.wasm.v1.MsgExecuteContract",
+					"/ibc.applications.transfer.v1.MsgTransfer",
 				},
 			}
 

--- a/cmd/junod/root.go
+++ b/cmd/junod/root.go
@@ -99,6 +99,7 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig) {
 		genutilcli.GenTxCmd(app.ModuleBasics, encodingConfig.TxConfig, banktypes.GenesisBalancesIterator{}, app.DefaultNodeHome),
 		genutilcli.ValidateGenesisCmd(app.ModuleBasics),
 		AddGenesisAccountCmd(app.DefaultNodeHome),
+		AddGenesisIcaCmd(app.DefaultNodeHome),
 		AddGenesisWasmMsgCmd(app.DefaultNodeHome),
 		tmcli.NewCompletionCmd(rootCmd, true),
 		// testnetCmd(app.ModuleBasics, banktypes.GenesisBalancesIterator{}),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,5 +11,5 @@ services:
       - 26656:26656 # p2p
       - 26657:26657 # rpc
     environment:
-      - GAS_LIMIT=${GAS_LIMIT:-100000000}
+      - GAS_LIMIT=${GAS_LIMIT:-10000000}
       - STAKE_TOKEN=${STAKE_TOKEN:-ujunox}

--- a/docker/setup_junod.sh
+++ b/docker/setup_junod.sh
@@ -19,6 +19,7 @@ else
   echo "$GENESIS_FILE does not exist. Generating..."
 
   junod init --chain-id "$CHAIN_ID" "$MONIKER"
+  junod add-ica-config
   # staking/governance token is hardcoded in config, change this
   sed -i "s/\"stake\"/\"$STAKE\"/" "$GENESIS_FILE"
   # this is essential for sub-1s block times (or header times go crazy)


### PR DESCRIPTION
Several improvements to catch minor issues with our Docker and ICA init from genesis

Closes #282

- Updates docker build to catch missed dependency change (wasmvm 1.0.0 -> 1.1.0)
- Enables cosmwasm1_1 in app features
- Adds missing genesis state in docker builds by default using a new cmd