### PR TITLE
fix: Ignoring error "validator is not a valid name or address…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,11 +39,12 @@ RUN chmod +x /opt/*.sh
 
 WORKDIR /opt
 
-# rest server
+## rest server
 EXPOSE 1317
 # tendermint p2p
 EXPOSE 26656
 # tendermint rpc
 EXPOSE 26657
+EXPOSE 9090
 
 CMD ["/usr/bin/junod", "version"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - 1317:1317 # rest
       - 26656:26656 # p2p
       - 26657:26657 # rpc
+      - 9090:9090 #grpc
     environment:
       - GAS_LIMIT=${GAS_LIMIT:-100000000}
       - STAKE_TOKEN=${STAKE_TOKEN:-ustake}

--- a/docker/run_junod.sh
+++ b/docker/run_junod.sh
@@ -6,4 +6,4 @@ if test -n "$1"; then
 fi
 
 mkdir -p /root/log
-junod start --rpc.laddr tcp://0.0.0.0:26657 --trace
+junod start --grpc.address tcp://0.0.0.0:9090 --rpc.laddr tcp://0.0.0.0:26657 --trace

--- a/docker/run_junod.sh
+++ b/docker/run_junod.sh
@@ -6,4 +6,5 @@ if test -n "$1"; then
 fi
 
 mkdir -p /root/log
-junod start --grpc.address tcp://0.0.0.0:9090 --rpc.laddr tcp://0.0.0.0:26657 --trace
+junod start --grpc.address tcp://0.0.0.0:9090 
+junod start --rpc.laddr tcp://0.0.0.0:26657 --trace

--- a/docker/setup_junod.sh
+++ b/docker/setup_junod.sh
@@ -43,7 +43,7 @@ if [ -n $UNSAFE_CORS ]; then
 fi
 
 # are we running for the first time?
-if ! junod keys show validator $KEYRING; then
+if ! junod keys show validator $KEYRING 2> /dev/null; then
   (echo "$PASSWORD"; echo "$PASSWORD") | junod keys add validator $KEYRING
 
   # hardcode the validator account for this instance


### PR DESCRIPTION
This error is fixing error "validator is not a valid name or address: decoding bech32 failed: invalid separator index -1"
When error is thrown, script is unable to call "junod gentx" and "add-genesys-account" functions.
The brings validator into invalid state, and junod returns another error "rpc error: code = NotFound desc = account" while signing transactions.