### PR TITLE
Integrate wasmd 0.29.0-rc1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.18
       - run: go build ./...
 
   test:
@@ -20,13 +20,13 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
+        go-version: 1.18
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Test
       run: go test ./...
 
-# Use --check or --exit-code when available (Go 1.19?)
+# Use --check or --exit-code when available (Go 1.18?)
 # https://github.com/golang/go/issues/27005
   tidy:
     runs-on: ubuntu-latest
@@ -36,7 +36,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.18
       - run: |
           go mod tidy
           CHANGES_IN_REPO=$(git status --porcelain)

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.18
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/.github/workflows/gov_deploy.yml
+++ b/.github/workflows/gov_deploy.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: 'CosmosContracts/cw-unity-prop'
-          ref: 'v0.3.3'
+          ref: 'v0.3.4-alpha'
       - name: Test gov deploy
         run: |
           chmod a+x ./scripts/deploy_ci.sh

--- a/.github/workflows/gov_submit.yml
+++ b/.github/workflows/gov_submit.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: 'CosmosContracts/cw-unity-prop'
-          ref: 'v0.3.3'
+          ref: 'v0.3.4-alpha'
       - name: Test smart contract gov prop
         run: |
           chmod a+x ./scripts/submit_gov_ci.sh

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: 'envoylabs/whoami'
-          ref: 'v0.7.0'
+          ref: 'v0.7.1-alpha'
       - name: Run deploy script
         run: |
           chmod a+x ./scripts/deploy_ci.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,10 @@ WORKDIR /code
 COPY . /code/
 
 # See https://github.com/CosmWasm/wasmvm/releases
-ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.1.0/libwasmvm_muslc.aarch64.a /lib/libwasmvm_muslc.aarch64.a
-ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.1.0/libwasmvm_muslc.x86_64.a /lib/libwasmvm_muslc.x86_64.a
-RUN sha256sum /lib/libwasmvm_muslc.aarch64.a | grep 728993b91b35037ae8d9933c3a9ee018e49a7926571ce4109f55d9954efcbe9a
-RUN sha256sum /lib/libwasmvm_muslc.x86_64.a | grep d06607db7bda6d3981f0717133584dd5480a6bca7b1e208b4526e68f3ccf3b31
+ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.1.1/libwasmvm_muslc.aarch64.a /lib/libwasmvm_muslc.aarch64.a
+ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.1.1/libwasmvm_muslc.x86_64.a /lib/libwasmvm_muslc.x86_64.a
+RUN sha256sum /lib/libwasmvm_muslc.aarch64.a | grep 9ecb037336bd56076573dc18c26631a9d2099a7f2b40dc04b6cae31ffb4c8f9a
+RUN sha256sum /lib/libwasmvm_muslc.x86_64.a | grep 6e4de7ba9bad4ae9679c7f9ecf7e283dd0160e71567c6a7be6ae47c81ebe7f32
 
 # Copy the library you want to the final location that will be found by the linker flag `-lwasmvm_muslc`
 RUN cp "/lib/libwasmvm_muslc.$(uname -m).a" /lib/libwasmvm_muslc.a

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,10 @@ WORKDIR /code
 COPY . /code/
 
 # See https://github.com/CosmWasm/wasmvm/releases
-ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.0.0/libwasmvm_muslc.aarch64.a /lib/libwasmvm_muslc.aarch64.a
-ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.0.0/libwasmvm_muslc.x86_64.a /lib/libwasmvm_muslc.x86_64.a
-RUN sha256sum /lib/libwasmvm_muslc.aarch64.a | grep 7d2239e9f25e96d0d4daba982ce92367aacf0cbd95d2facb8442268f2b1cc1fc
-RUN sha256sum /lib/libwasmvm_muslc.x86_64.a | grep f6282df732a13dec836cda1f399dd874b1e3163504dbd9607c6af915b2740479
+ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.1.0/libwasmvm_muslc.aarch64.a /lib/libwasmvm_muslc.aarch64.a
+ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.1.0/libwasmvm_muslc.x86_64.a /lib/libwasmvm_muslc.x86_64.a
+RUN sha256sum /lib/libwasmvm_muslc.aarch64.a | grep 728993b91b35037ae8d9933c3a9ee018e49a7926571ce4109f55d9954efcbe9a
+RUN sha256sum /lib/libwasmvm_muslc.x86_64.a | grep d06607db7bda6d3981f0717133584dd5480a6bca7b1e208b4526e68f3ccf3b31
 
 # Copy the library you want to the final location that will be found by the linker flag `-lwasmvm_muslc`
 RUN cp "/lib/libwasmvm_muslc.$(uname -m).a" /lib/libwasmvm_muslc.a

--- a/app/app.go
+++ b/app/app.go
@@ -455,7 +455,7 @@ func New(
 
 	// The last arguments can contain custom message handlers, and custom query handlers,
 	// if we want to allow any custom callbacks
-	supportedFeatures := "iterator,staking,stargate"
+	supportedFeatures := "iterator,staking,stargate,cosmwasm_1_1"
 	app.wasmKeeper = wasm.NewKeeper(
 		appCodec,
 		keys[wasm.StoreKey],

--- a/cmd/junod/genica.go
+++ b/cmd/junod/genica.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/spf13/cobra"
+
+	icacontrollertypes "github.com/cosmos/ibc-go/v3/modules/apps/27-interchain-accounts/controller/types"
+	icahosttypes "github.com/cosmos/ibc-go/v3/modules/apps/27-interchain-accounts/host/types"
+	icatypes "github.com/cosmos/ibc-go/v3/modules/apps/27-interchain-accounts/types"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/server"
+	"github.com/cosmos/cosmos-sdk/x/genutil"
+	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
+)
+
+// AddGenesisAccountCmd returns add-genesis-account cobra Command.
+func AddGenesisIcaCmd(defaultNodeHome string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "add-ica-config",
+		Short: "Add ICA config to genesis.json",
+		Long:  `Add default ICA configuration to genesis.json`,
+		Args:  cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx := client.GetClientContextFromCmd(cmd)
+			serverCtx := server.GetServerContextFromCmd(cmd)
+			config := serverCtx.Config
+
+			config.SetRoot(clientCtx.HomeDir)
+
+			genFile := config.GenesisFile()
+			appState, genDoc, err := genutiltypes.GenesisStateFromGenFile(genFile)
+			if err != nil {
+				return fmt.Errorf("failed to unmarshal genesis state: %w", err)
+			}
+
+			controllerGenesisState := icatypes.DefaultControllerGenesis()
+			// no params set in upgrade handler, no params set here
+			controllerGenesisState.Params = icacontrollertypes.Params{}
+
+			hostGenesisState := icatypes.DefaultHostGenesis()
+			// add the messages we want
+			hostGenesisState.Params = icahosttypes.Params{
+				HostEnabled: true,
+				AllowMessages: []string{
+					"/cosmos.bank.v1beta1.MsgSend",
+					"/cosmos.staking.v1beta1.MsgDelegate",
+					"/cosmos.staking.v1beta1.MsgBeginRedelegate",
+					"/cosmos.staking.v1beta1.MsgCreateValidator",
+					"/cosmos.staking.v1beta1.MsgEditValidator",
+					"/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward",
+					"/cosmos.distribution.v1beta1.MsgSetWithdrawAddress",
+					"/cosmos.distribution.v1beta1.MsgWithdrawValidatorCommission",
+					"/cosmos.distribution.v1beta1.MsgFundCommunityPool",
+					"/cosmos.gov.v1beta1.MsgVote",
+					"/cosmos.authz.v1beta1.MsgExec",
+					"/cosmos.authz.v1beta1.MsgGrant",
+					"/cosmos.authz.v1beta1.MsgRevoke",
+					"/cosmwasm.wasm.v1.MsgStoreCode",
+					"/cosmwasm.wasm.v1.MsgInstantiateContract",
+					"/cosmwasm.wasm.v1.MsgExecuteContract",
+				},
+			}
+
+			newIcaGenState := icatypes.NewGenesisState(controllerGenesisState, hostGenesisState)
+
+			icaGenStateBz, err := clientCtx.Codec.MarshalJSON(newIcaGenState)
+			if err != nil {
+				return fmt.Errorf("failed to marshal auth genesis state: %w", err)
+			}
+
+			appState[icatypes.ModuleName] = icaGenStateBz
+
+			appStateJSON, err := json.Marshal(appState)
+			if err != nil {
+				return fmt.Errorf("failed to marshal application genesis state: %w", err)
+			}
+
+			genDoc.AppState = appStateJSON
+			return genutil.ExportGenesisFile(genDoc, genFile)
+		},
+	}
+
+	cmd.Flags().String(flags.FlagHome, defaultNodeHome, "The application home directory")
+	cmd.Flags().String(flags.FlagKeyringBackend, flags.DefaultKeyringBackend, "Select keyring's backend (os|file|kwallet|pass|test)")
+
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}

--- a/cmd/junod/root.go
+++ b/cmd/junod/root.go
@@ -99,6 +99,7 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig) {
 		genutilcli.GenTxCmd(app.ModuleBasics, encodingConfig.TxConfig, banktypes.GenesisBalancesIterator{}, app.DefaultNodeHome),
 		genutilcli.ValidateGenesisCmd(app.ModuleBasics),
 		AddGenesisAccountCmd(app.DefaultNodeHome),
+		AddGenesisIcaCmd(app.DefaultNodeHome),
 		AddGenesisWasmMsgCmd(app.DefaultNodeHome),
 		tmcli.NewCompletionCmd(rootCmd, true),
 		// testnetCmd(app.ModuleBasics, banktypes.GenesisBalancesIterator{}),

--- a/docker/setup_junod.sh
+++ b/docker/setup_junod.sh
@@ -19,6 +19,7 @@ else
   echo "$GENESIS_FILE does not exist. Generating..."
 
   junod init --chain-id "$CHAIN_ID" "$MONIKER"
+  junod add-ica-config
   # staking/governance token is hardcoded in config, change this
   sed -i "s/\"stake\"/\"$STAKE\"/" "$GENESIS_FILE"
   # this is essential for sub-1s block times (or header times go crazy)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/CosmosContracts/juno/v10
 go 1.18
 
 require (
-	github.com/CosmWasm/wasmd v0.29.0-rc0
+	github.com/CosmWasm/wasmd v0.29.0-rc1
 	github.com/cosmos/cosmos-sdk v0.45.8
 	github.com/cosmos/ibc-go/v3 v3.3.0
 	github.com/gogo/protobuf v1.3.3
@@ -27,7 +27,7 @@ require (
 	github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 // indirect
 	github.com/99designs/keyring v1.2.1 // indirect
 	github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d // indirect
-	github.com/CosmWasm/wasmvm v1.1.0 // indirect
+	github.com/CosmWasm/wasmvm v1.1.1 // indirect
 	github.com/Workiva/go-datastructures v1.0.53 // indirect
 	github.com/armon/go-metrics v0.4.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,12 @@ github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d h1:nalkkPQ
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d/go.mod h1:URdX5+vg25ts3aCh8H5IFZybJYKWhJHYMTnf+ULtoC4=
 github.com/CosmWasm/wasmd v0.29.0-rc0 h1:eY/tC5tS0C7DJ+AT8nS2M/DNPe8lvKaM/3tB7dq5m4s=
 github.com/CosmWasm/wasmd v0.29.0-rc0/go.mod h1:2rlBUuIRTZxVbllwUH0GYHV1ZEJtBakSftbidKeDED0=
+github.com/CosmWasm/wasmd v0.29.0-rc1 h1:5lvbzKkstmYFVBv1NomQqUAkun7iz6M4sE3AUBHC9Iw=
+github.com/CosmWasm/wasmd v0.29.0-rc1/go.mod h1:eRrfjYNj8/PhyA2wdIuHeR/Czjy9/1UGuIr0NJocleA=
 github.com/CosmWasm/wasmvm v1.1.0 h1:FLd2njaJcZPgq/yLrXtQdndg0oG/QySKpWyVP2tBCnQ=
 github.com/CosmWasm/wasmvm v1.1.0/go.mod h1:ei0xpvomwSdONsxDuONzV7bL1jSET1M8brEx0FCXc+A=
+github.com/CosmWasm/wasmvm v1.1.1 h1:0xtdrmmsP9fibe+x42WcMkp5aQ738BICgcH3FNVLzm4=
+github.com/CosmWasm/wasmvm v1.1.1/go.mod h1:ei0xpvomwSdONsxDuONzV7bL1jSET1M8brEx0FCXc+A=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/DataDog/zstd v1.4.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=

--- a/go.sum
+++ b/go.sum
@@ -59,12 +59,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d h1:nalkkPQcITbvhmL4+C4cKA87NW0tfm3Kl9VXRoPywFg=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d/go.mod h1:URdX5+vg25ts3aCh8H5IFZybJYKWhJHYMTnf+ULtoC4=
-github.com/CosmWasm/wasmd v0.29.0-rc0 h1:eY/tC5tS0C7DJ+AT8nS2M/DNPe8lvKaM/3tB7dq5m4s=
-github.com/CosmWasm/wasmd v0.29.0-rc0/go.mod h1:2rlBUuIRTZxVbllwUH0GYHV1ZEJtBakSftbidKeDED0=
 github.com/CosmWasm/wasmd v0.29.0-rc1 h1:5lvbzKkstmYFVBv1NomQqUAkun7iz6M4sE3AUBHC9Iw=
 github.com/CosmWasm/wasmd v0.29.0-rc1/go.mod h1:eRrfjYNj8/PhyA2wdIuHeR/Czjy9/1UGuIr0NJocleA=
-github.com/CosmWasm/wasmvm v1.1.0 h1:FLd2njaJcZPgq/yLrXtQdndg0oG/QySKpWyVP2tBCnQ=
-github.com/CosmWasm/wasmvm v1.1.0/go.mod h1:ei0xpvomwSdONsxDuONzV7bL1jSET1M8brEx0FCXc+A=
 github.com/CosmWasm/wasmvm v1.1.1 h1:0xtdrmmsP9fibe+x42WcMkp5aQ738BICgcH3FNVLzm4=
 github.com/CosmWasm/wasmvm v1.1.1/go.mod h1:ei0xpvomwSdONsxDuONzV7bL1jSET1M8brEx0FCXc+A=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=


### PR DESCRIPTION
This version of wasmd includes: 

- support for patched IBC-go (3.3.0)
- different implementation of deterministic addresses from rc0
- support for SDK 45.8
- wasmvm 1.1.1 (mitigates cache error found on uni3)