### PR TITLE
Reset application.db and  wasm

### DIFF
--- a/cmd/junod/root.go
+++ b/cmd/junod/root.go
@@ -121,6 +121,7 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig) {
 		queryCommand(),
 		txCommand(),
 		keys.Commands(app.DefaultNodeHome),
+		ResetWasmCmd,
 	)
 }
 

--- a/cmd/junod/root.go
+++ b/cmd/junod/root.go
@@ -122,6 +122,7 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig) {
 		txCommand(),
 		keys.Commands(app.DefaultNodeHome),
 		ResetWasmCmd,
+		ResetAppCmd,
 	)
 }
 

--- a/cmd/junod/tendermint.go
+++ b/cmd/junod/tendermint.go
@@ -50,12 +50,12 @@ func resetWasm(dbDir string) error {
 		if err := os.RemoveAll(wasmDir); err == nil {
 			fmt.Println("Removed wasm", "dir", wasmDir)
 		} else {
-			fmt.Println("error removing wasm", "dir", wasmDir, "err", err)
+			return fmt.Errorf("error removing wasm  dir: %s; err: %w", wasmDir, err)
 		}
 	}
 
 	if err := tmos.EnsureDir(wasmDir, 0700); err != nil {
-		fmt.Println("unable to recreate wasm", "err", err)
+		return fmt.Errorf("unable to recreate wasm %w", err)
 	}
 	return nil
 }
@@ -68,12 +68,12 @@ func resetApp(dbDir string) error {
 		if err := os.RemoveAll(appDir); err == nil {
 			fmt.Println("Removed application.db", "dir", appDir)
 		} else {
-			fmt.Println("error removing application.db", "dir", appDir, "err", err)
+			return fmt.Errorf("error removing application.db  dir: %s; err: %w", appDir, err)
 		}
 	}
 
 	if err := tmos.EnsureDir(appDir, 0700); err != nil {
-		fmt.Println("unable to recreate application.db", "err", err)
+		return fmt.Errorf("unable to recreate application.db %w", err)
 	}
 	return nil
 }

--- a/cmd/junod/tendermint.go
+++ b/cmd/junod/tendermint.go
@@ -14,8 +14,8 @@ import (
 
 // ResetWasmCmd removes the database of the specified Tendermint core instance.
 var ResetWasmCmd = &cobra.Command{
-	Use:   "reset-app-wasm",
-	Short: "Remove App and WASM files",
+	Use:   "reset-wasm",
+	Short: "Remove WASM files",
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		clientCtx := client.GetClientContextFromCmd(cmd)
 		serverCtx := server.GetServerContextFromCmd(cmd)
@@ -27,32 +27,53 @@ var ResetWasmCmd = &cobra.Command{
 	},
 }
 
-func init() {
+// ResetWasmCmd removes the database of the specified Tendermint core instance.
+var ResetAppCmd = &cobra.Command{
+	Use:   "reset-app",
+	Short: "Remove App files",
+	RunE: func(cmd *cobra.Command, args []string) (err error) {
+		clientCtx := client.GetClientContextFromCmd(cmd)
+		serverCtx := server.GetServerContextFromCmd(cmd)
+		config := serverCtx.Config
+
+		config.SetRoot(clientCtx.HomeDir)
+
+		return resetApp(config.DBDir())
+	},
 }
 
 // resetWasm removes wasm files
 func resetWasm(dbDir string) error {
-	application := filepath.Join(dbDir, "application.db")
-	wasm := filepath.Join(dbDir, "wasm")
+	wasmDir := filepath.Join(dbDir, "wasm")
 
-	if tmos.FileExists(application) {
-		if err := os.RemoveAll(application); err == nil {
-			fmt.Println("Removed all application.db", "dir", application)
+	if tmos.FileExists(wasmDir) {
+		if err := os.RemoveAll(wasmDir); err == nil {
+			fmt.Println("Removed wasm", "dir", wasmDir)
 		} else {
-			fmt.Println("error removing all application.db", "dir", application, "err", err)
+			fmt.Println("error removing wasm", "dir", wasmDir, "err", err)
 		}
 	}
 
-	if tmos.FileExists(wasm) {
-		if err := os.RemoveAll(wasm); err == nil {
-			fmt.Println("Removed all wasm", "dir", wasm)
+	if err := tmos.EnsureDir(wasmDir, 0700); err != nil {
+		fmt.Println("unable to recreate wasm", "err", err)
+	}
+	return nil
+}
+
+// resetApp removes application.db files
+func resetApp(dbDir string) error {
+	appDir := filepath.Join(dbDir, "application.db")
+
+	if tmos.FileExists(appDir) {
+		if err := os.RemoveAll(appDir); err == nil {
+			fmt.Println("Removed application.db", "dir", appDir)
 		} else {
-			fmt.Println("error removing all wasm", "dir", wasm, "err", err)
+			fmt.Println("error removing application.db", "dir", appDir, "err", err)
 		}
 	}
 
-	if err := tmos.EnsureDir(dbDir, 0700); err != nil {
-		fmt.Println("unable to recreate dbDir", "err", err)
+	if err := tmos.EnsureDir(appDir, 0700); err != nil {
+		fmt.Println("unable to recreate application.db", "err", err)
 	}
 	return nil
 }

--- a/cmd/junod/tendermint.go
+++ b/cmd/junod/tendermint.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/server"
+	tmos "github.com/tendermint/tendermint/libs/os"
+)
+
+// ResetWasmCmd removes the database of the specified Tendermint core instance.
+var ResetWasmCmd = &cobra.Command{
+	Use:   "reset-app-wasm",
+	Short: "Remove App and WASM files",
+	RunE: func(cmd *cobra.Command, args []string) (err error) {
+		clientCtx := client.GetClientContextFromCmd(cmd)
+		serverCtx := server.GetServerContextFromCmd(cmd)
+		config := serverCtx.Config
+
+		config.SetRoot(clientCtx.HomeDir)
+
+		return resetWasm(config.DBDir())
+	},
+}
+
+func init() {
+}
+
+// resetWasm removes wasm files
+func resetWasm(dbDir string) error {
+	application := filepath.Join(dbDir, "application.db")
+	wasm := filepath.Join(dbDir, "wasm")
+
+	if tmos.FileExists(application) {
+		if err := os.RemoveAll(application); err == nil {
+			fmt.Println("Removed all application.db", "dir", application)
+		} else {
+			fmt.Println("error removing all application.db", "dir", application, "err", err)
+		}
+	}
+
+	if tmos.FileExists(wasm) {
+		if err := os.RemoveAll(wasm); err == nil {
+			fmt.Println("Removed all wasm", "dir", wasm)
+		} else {
+			fmt.Println("error removing all wasm", "dir", wasm, "err", err)
+		}
+	}
+
+	if err := tmos.EnsureDir(dbDir, 0700); err != nil {
+		fmt.Println("unable to recreate dbDir", "err", err)
+	}
+	return nil
+}


### PR DESCRIPTION
Is there a better way to reset application.db and wasm?  For example by extending into the "tendermint" reset-state command? 