### PR TITLE
fix(Dockerfile): latest alpine, use sh, combine run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,15 @@
 # docker build . -t cosmoscontracts/juno:latest
 # docker run --rm -it cosmoscontracts/juno:latest /bin/sh
-FROM golang:1.18-alpine3.15 AS go-builder
+FROM golang:1.18-alpine AS go-builder
 
 # this comes from standard alpine nightly file
 #  https://github.com/rust-lang/docker-rust-nightly/blob/master/alpine3.12/Dockerfile
 # with some changes to support our toolchain, etc
-SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
+SHELL ["/bin/sh", "-ecuxo", "pipefail"]
 # we probably want to default to latest and error
 # since this is predominantly for dev use
 # hadolint ignore=DL3018
-RUN set -eux; apk add --no-cache ca-certificates build-base;
-
-# hadolint ignore=DL3018
-RUN apk add git
+RUN apk add --no-cache ca-certificates build-base git
 # NOTE: add these to run with LEDGER_ENABLED=true
 # RUN apk add libusb-dev linux-headers
 
@@ -37,7 +34,7 @@ RUN LEDGER_ENABLED=false BUILD_TAGS=muslc LINK_STATICALLY=true make build \
   && (file /code/bin/junod | grep "statically linked")
 
 # --------------------------------------------------------
-FROM alpine:3.15
+FROM alpine:3.16
 
 COPY --from=go-builder /code/bin/junod /usr/bin/junod
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,4 +50,5 @@ EXPOSE 26656
 # tendermint rpc
 EXPOSE 26657
 
-CMD ["/usr/bin/junod", "version"]
+ENTRYPOINT ["/usr/bin/junod"]
+CMD ["version"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,5 +50,4 @@ EXPOSE 26656
 # tendermint rpc
 EXPOSE 26657
 
-ENTRYPOINT ["/usr/bin/junod"]
-CMD ["version"]
+CMD ["/usr/bin/junod", "version"]


### PR DESCRIPTION
- Use latest alpine based golang image
- Use sh just to standardized shells
- combine `RUN` instructions
- Use `entrypoint` to handle os signals
