### PR TITLE
gives Juno the canonical cmd folder structure

### DIFF
--- a/cmd/junod/cmd/genaccounts.go
+++ b/cmd/junod/cmd/genaccounts.go
@@ -1,4 +1,4 @@
-package main
+package cmd
 
 import (
 	"bufio"

--- a/cmd/junod/cmd/genica.go
+++ b/cmd/junod/cmd/genica.go
@@ -1,8 +1,9 @@
-package main
+package cmd
 
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/spf13/cobra"
 
 	icacontrollertypes "github.com/cosmos/ibc-go/v3/modules/apps/27-interchain-accounts/controller/types"

--- a/cmd/junod/cmd/genwasm.go
+++ b/cmd/junod/cmd/genwasm.go
@@ -1,4 +1,4 @@
-package main
+package cmd
 
 import (
 	"github.com/cosmos/cosmos-sdk/client"

--- a/cmd/junod/cmd/root.go
+++ b/cmd/junod/cmd/root.go
@@ -1,4 +1,4 @@
-package main
+package cmd
 
 import (
 	"errors"

--- a/cmd/junod/cmd/tendermint.go
+++ b/cmd/junod/cmd/tendermint.go
@@ -1,4 +1,4 @@
-package main
+package cmd
 
 import (
 	"fmt"
@@ -54,7 +54,7 @@ func resetWasm(dbDir string) error {
 		}
 	}
 
-	if err := tmos.EnsureDir(wasmDir, 0700); err != nil {
+	if err := tmos.EnsureDir(wasmDir, 0o700); err != nil {
 		return fmt.Errorf("unable to recreate wasm %w", err)
 	}
 	return nil
@@ -72,7 +72,7 @@ func resetApp(dbDir string) error {
 		}
 	}
 
-	if err := tmos.EnsureDir(appDir, 0700); err != nil {
+	if err := tmos.EnsureDir(appDir, 0o700); err != nil {
 		return fmt.Errorf("unable to recreate application.db %w", err)
 	}
 	return nil

--- a/cmd/junod/main.go
+++ b/cmd/junod/main.go
@@ -4,13 +4,14 @@ import (
 	"os"
 
 	"github.com/CosmosContracts/juno/v12/app"
+	"github.com/CosmosContracts/juno/v12/cmd/junod/cmd"
 	"github.com/cosmos/cosmos-sdk/server"
 
 	svrcmd "github.com/cosmos/cosmos-sdk/server/cmd"
 )
 
 func main() {
-	rootCmd, _ := NewRootCmd()
+	rootCmd, _ := cmd.NewRootCmd()
 	if err := svrcmd.Execute(rootCmd, app.DefaultNodeHome); err != nil {
 		switch e := err.(type) {
 		case server.ErrorCode:


### PR DESCRIPTION
This PR makes juno have a standard cmd folder layout per cosmos-sdk style.