### PR TITLE
Use go 1.19

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,6 @@
 on: [push, pull_request]
 name: every commit
 jobs:
-
   build:
     runs-on: ubuntu-latest
     name: build
@@ -11,24 +10,24 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
       - run: go build ./...
 
   test:
     runs-on: ubuntu-latest
     name: test
     steps:
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.18
-    - name: Checkout code
-      uses: actions/checkout@v3
-    - name: Test
-      run: go test ./...
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Test
+        run: go test ./...
 
-# Use --check or --exit-code when available (Go 1.18?)
-# https://github.com/golang/go/issues/27005
+  # Use --check or --exit-code when available (Go 1.18?)
+  # https://github.com/golang/go/issues/27005
   tidy:
     runs-on: ubuntu-latest
     name: tidy
@@ -37,7 +36,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
       - run: |
           go mod tidy
           CHANGES_IN_REPO=$(git status --porcelain)

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # docker build . -t cosmoscontracts/juno:latest
 # docker run --rm -it cosmoscontracts/juno:latest /bin/sh
-FROM golang:1.18-alpine AS go-builder
+FROM golang:1.19-alpine AS go-builder
 
 # this comes from standard alpine nightly file
 #  https://github.com/rust-lang/docker-rust-nightly/blob/master/alpine3.12/Dockerfile

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/CosmosContracts/juno/v12
 
-go 1.18
+go 1.19
 
 require (
 	github.com/CosmWasm/token-factory v0.0.0-20221024170206-1345f322c887


### PR DESCRIPTION
This PR responds to validator feedback by mandating the use of go 1.19.  Our next state breaking change (v13) is a good time to do this and we will then be able to ensure that all validators are using the same version of Go when they build the binary. 