### PR TITLE
Faddat/mev experiment

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/spf13/cast v1.5.0
 	github.com/spf13/cobra v1.6.0
 	github.com/stretchr/testify v1.8.0
-	github.com/tendermint/tendermint v0.34.23
+	github.com/tendermint/tendermint v0.34.24
 	github.com/tendermint/tm-db v0.6.7
 	google.golang.org/genproto v0.0.0-20221014213838-99cd37c6964a
 	google.golang.org/grpc v1.50.1

--- a/go.sum
+++ b/go.sum
@@ -766,8 +766,8 @@ github.com/tendermint/crypto v0.0.0-20191022145703-50d29ede1e15 h1:hqAk8riJvK4RM
 github.com/tendermint/crypto v0.0.0-20191022145703-50d29ede1e15/go.mod h1:z4YtwM70uOnk8h0pjJYlj3zdYwi9l03By6iAIF5j/Pk=
 github.com/tendermint/go-amino v0.16.0 h1:GyhmgQKvqF82e2oZeuMSp9JTN0N09emoSZlb2lyGa2E=
 github.com/tendermint/go-amino v0.16.0/go.mod h1:TQU0M1i/ImAo+tYpZi73AU3V/dKeCoMC9Sphe2ZwGME=
-github.com/tendermint/tendermint v0.34.23 h1:JZYsdc59aOiT5efou+BHILJv8x6FlRyvlor84Xq9Tb0=
-github.com/tendermint/tendermint v0.34.23/go.mod h1:rXVrl4OYzmIa1I91av3iLv2HS0fGSiucyW9J4aMTpKI=
+github.com/tendermint/tendermint v0.34.24 h1:879MKKJWYYPJEMMKME+DWUTY4V9f/FBpnZDI82ky+4k=
+github.com/tendermint/tendermint v0.34.24/go.mod h1:rXVrl4OYzmIa1I91av3iLv2HS0fGSiucyW9J4aMTpKI=
 github.com/tendermint/tm-db v0.6.7 h1:fE00Cbl0jayAoqlExN6oyQJ7fR/ZtoVOmvPJ//+shu8=
 github.com/tendermint/tm-db v0.6.7/go.mod h1:byQDzFkZV1syXr/ReXS808NxA2xvyuuVgXOJ/088L6I=
 github.com/tidwall/gjson v1.6.7/go.mod h1:zeFuBCIqD4sN/gmqBzZ4j7Jd6UcA2Fc56x7QFsv+8fI=

--- a/scripts/statesync-mev.bash
+++ b/scripts/statesync-mev.bash
@@ -26,6 +26,7 @@ junod init test
 aria2c https://download.dimi.sh/juno-phoenix2-genesis.tar.gz
 tar -xvf juno-phoenix2-genesis.tar.gz
 mv juno-phoenix2-genesis.json "$HOME/.juno/config/genesis.json"
+rm juno-phoenix2-genesis.tar.gz
 
 # Get "trust_hash" and "trust_height".
 INTERVAL=1000

--- a/scripts/statesync-mev.bash
+++ b/scripts/statesync-mev.bash
@@ -23,7 +23,7 @@ go install -ldflags '-w -s -X github.com/cosmos/cosmos-sdk/types.DBBackend=pebbl
 junod init test
 
 # Get Genesis
-wget https://download.dimi.sh/juno-phoenix2-genesis.tar.gz
+aria2c https://download.dimi.sh/juno-phoenix2-genesis.tar.gz
 tar -xvf juno-phoenix2-genesis.tar.gz
 mv juno-phoenix2-genesis.json "$HOME/.juno/config/genesis.json"
 
@@ -40,7 +40,7 @@ echo "trust_hash: $TRUST_HASH"
 # Export state sync variables.
 export JUNOD_STATESYNC_ENABLE=true
 export JUNOD_P2P_MAX_NUM_OUTBOUND_PEERS=200
-export JUNOD_STATESYNC_RPC_SERVERS="https://rpc-juno-ia.notional.ventures:443,https://juno-rpc.polkachu.com:443"
+export JUNOD_STATESYNC_RPC_SERVERS="https://juno-rpc.polkachu.com:443,https://rpc-juno-ia.notional.ventures:443,https://juno-rpc.polkachu.com:443"
 export JUNOD_STATESYNC_TRUST_HEIGHT=$BLOCK_HEIGHT
 export JUNOD_STATESYNC_TRUST_HASH=$TRUST_HASH
 

--- a/scripts/statesync-mev.bash
+++ b/scripts/statesync-mev.bash
@@ -1,0 +1,52 @@
+#!/bin/bash
+# microtick and bitcanna contributed significantly here.
+# Pebbledb state sync script.
+set -uxe
+
+# Set Golang environment variables.
+export GOPATH=~/go
+export PATH=$PATH:~/go/bin
+
+# Install Juno with pebbledb
+go mod edit -replace github.com/tendermint/tm-db=github.com/baabeetaa/tm-db@pebble
+go mod tidy -go=1.19
+go mod edit -replace github.com/tendermint/tendermint=github.com/notional-labs/mev-tendermint@0db69e64a2e87bb29b4417780da30630df97cadd
+go mod tidy
+go install -ldflags '-w -s -X github.com/cosmos/cosmos-sdk/types.DBBackend=pebbledb -X github.com/tendermint/tm-db.ForceSync=1' -tags pebbledb ./...
+
+# NOTE: ABOVE YOU CAN USE ALTERNATIVE DATABASES, HERE ARE THE EXACT COMMANDS
+# go install -ldflags '-w -s -X github.com/cosmos/cosmos-sdk/types.DBBackend=rocksdb' -tags rocksdb ./...
+# go install -ldflags '-w -s -X github.com/cosmos/cosmos-sdk/types.DBBackend=badgerdb' -tags badgerdb ./...
+# go install -ldflags '-w -s -X github.com/cosmos/cosmos-sdk/types.DBBackend=boltdb' -tags boltdb ./...
+
+# Initialize chain.
+junod init test
+
+# Get Genesis
+wget https://download.dimi.sh/juno-phoenix2-genesis.tar.gz
+tar -xvf juno-phoenix2-genesis.tar.gz
+mv juno-phoenix2-genesis.json "$HOME/.juno/config/genesis.json"
+
+# Get "trust_hash" and "trust_height".
+INTERVAL=1000
+LATEST_HEIGHT="$(curl -s https://juno-rpc.polkachu.com/block | jq -r .result.block.header.height)"
+BLOCK_HEIGHT="$((LATEST_HEIGHT - INTERVAL))"
+TRUST_HASH="$(curl -s "https://juno-rpc.polkachu.com/block?height=$BLOCK_HEIGHT" | jq -r .result.block_id.hash)"
+
+# Print out block and transaction hash from which to sync state.
+echo "trust_height: $BLOCK_HEIGHT"
+echo "trust_hash: $TRUST_HASH"
+
+# Export state sync variables.
+export JUNOD_STATESYNC_ENABLE=true
+export JUNOD_P2P_MAX_NUM_OUTBOUND_PEERS=200
+export JUNOD_STATESYNC_RPC_SERVERS="https://rpc-juno-ia.notional.ventures:443,https://juno-rpc.polkachu.com:443"
+export JUNOD_STATESYNC_TRUST_HEIGHT=$BLOCK_HEIGHT
+export JUNOD_STATESYNC_TRUST_HASH=$TRUST_HASH
+
+# Fetch and set list of seeds from chain registry.
+JUNOD_P2P_SEEDS="$(curl -s https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/chain.json | jq -r '[foreach .peers.seeds[] as $item (""; "\($item.id)@\($item.address)")] | join(",")')"
+export JUNOD_P2P_SEEDS
+
+# Start chain.
+junod start --x-crisis-skip-assert-invariants --db_backend pebbledb


### PR DESCRIPTION
This is for Juno validators using tendermint-mev **to test outside their validator nodes**

* you do not need to be using Skip in order to use this work
* to integrate this on your validator node, you'd simply run this binary
* the p2p logs will look different, because I've changed them in this:
  * https://github.com/notional-labs/mev-tendermint/tree/v0.34.x-mev-gadikian 
* speaking as myself only, I'm interested in seeing this become Juno's canonical binary, regardless of weather validators are using Skip or not.

```bash
bash scripts/statesync-mev.bash
```

## More context

The tendermint core repository is reather difficult to ship improvements to, this PR is going straight to the point:

* only pebbledb is supported for tendermint's store
* cosmos-sdk still supports goleveldb and maybe others but I think that the 5x reduction in RAM usage seen on Osmosis archive nodes when using pebble -- and associated big reductions in complexity is a great reason to take these choices away from infrastructure operators and instead use the clear sane default.
* Notional's validator will soon use this build in order to prove its viability.