### PR TITLE
chore: Move reset-* commands to a subcmd (less rootCmd spam)

### DIFF
--- a/cmd/junod/cmd/resets.go
+++ b/cmd/junod/cmd/resets.go
@@ -12,6 +12,20 @@ import (
 	tmos "github.com/tendermint/tendermint/libs/os"
 )
 
+// Cmd creates a main CLI command
+func ResetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "reset",
+		Short: "Reset commands for different parts of application state",
+		RunE:  client.ValidateCmd,
+	}
+
+	cmd.AddCommand(ResetWasmCmd)
+	cmd.AddCommand(ResetAppCmd)
+
+	return cmd
+}
+
 // ResetWasmCmd removes the database of the specified Tendermint core instance.
 var ResetWasmCmd = &cobra.Command{
 	Use:   "reset-wasm",

--- a/cmd/junod/cmd/resets.go
+++ b/cmd/junod/cmd/resets.go
@@ -28,8 +28,8 @@ func ResetCmd() *cobra.Command {
 
 // ResetWasmCmd removes the database of the specified Tendermint core instance.
 var ResetWasmCmd = &cobra.Command{
-	Use:   "reset-wasm",
-	Short: "Remove WASM files",
+	Use:   "wasm",
+	Short: "Reset WASM files",
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		clientCtx := client.GetClientContextFromCmd(cmd)
 		serverCtx := server.GetServerContextFromCmd(cmd)
@@ -43,8 +43,8 @@ var ResetWasmCmd = &cobra.Command{
 
 // ResetWasmCmd removes the database of the specified Tendermint core instance.
 var ResetAppCmd = &cobra.Command{
-	Use:   "reset-app",
-	Short: "Remove App files",
+	Use:   "app",
+	Short: "Reset App files",
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		clientCtx := client.GetClientContextFromCmd(cmd)
 		serverCtx := server.GetServerContextFromCmd(cmd)

--- a/cmd/junod/cmd/root.go
+++ b/cmd/junod/cmd/root.go
@@ -121,8 +121,7 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig) {
 		queryCommand(),
 		txCommand(),
 		keys.Commands(app.DefaultNodeHome),
-		ResetWasmCmd,
-		ResetAppCmd,
+		ResetCmd(),
 	)
 }
 


### PR DESCRIPTION
This cleans up the main root command
```
junod reset-app
junod reset-wasm
```

Moved to its own sub-cmd
```
junod reset app
junod reset wasm
```