### PR TITLE
Oracle tests: multiple denom, denom with no entries; endBlocker tests

### DIFF
--- a/x/oracle/abci_test.go
+++ b/x/oracle/abci_test.go
@@ -1,0 +1,165 @@
+package oracle_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/cosmos/cosmos-sdk/simapp"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
+	"github.com/cosmos/cosmos-sdk/x/staking"
+	"github.com/cosmos/cosmos-sdk/x/staking/teststaking"
+	"github.com/stretchr/testify/suite"
+	"github.com/tendermint/tendermint/crypto/secp256k1"
+	tmrand "github.com/tendermint/tendermint/libs/rand"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+
+	app "github.com/CosmosContracts/juno/v12/app"
+	appparams "github.com/CosmosContracts/juno/v12/app/params"
+	"github.com/CosmosContracts/juno/v12/x/oracle"
+	"github.com/CosmosContracts/juno/v12/x/oracle/types"
+)
+
+const (
+	displayDenom string = appparams.DisplayDenom
+	bondDenom    string = appparams.BondDenom
+)
+
+type IntegrationTestSuite struct {
+	suite.Suite
+
+	ctx sdk.Context
+	app *app.App
+}
+
+const (
+	initialPower = int64(10000000000)
+)
+
+func (s *IntegrationTestSuite) SetupTest() {
+	require := s.Require()
+	isCheckTx := false
+	app := app.Setup(s.T(), isCheckTx, 1)
+	ctx := app.BaseApp.NewContext(isCheckTx, tmproto.Header{
+		ChainID: fmt.Sprintf("test-chain-%s", tmrand.Str(4)),
+	})
+
+	oracle.InitGenesis(ctx, app.OracleKeeper, *types.DefaultGenesisState())
+
+	sh := teststaking.NewHelper(s.T(), ctx, app.StakingKeeper)
+	sh.Denom = bondDenom
+	amt := sdk.TokensFromConsensusPower(100, sdk.DefaultPowerReduction)
+
+	// mint and send coins to validator
+	require.NoError(app.BankKeeper.MintCoins(ctx, minttypes.ModuleName, initCoins))
+	require.NoError(app.BankKeeper.SendCoinsFromModuleToAccount(ctx, minttypes.ModuleName, addr, initCoins))
+
+	sh.CreateValidator(valAddr, valPubKey, amt, true)
+
+	staking.EndBlocker(ctx, app.StakingKeeper)
+
+	s.app = app
+	s.ctx = ctx
+}
+
+// Test addresses
+var (
+	valPubKeys = simapp.CreateTestPubKeys(1)
+
+	valPubKey = valPubKeys[0]
+	pubKey    = secp256k1.GenPrivKey().PubKey()
+	addr      = sdk.AccAddress(pubKey.Address())
+	valAddr   = sdk.ValAddress(pubKey.Address())
+
+	initTokens = sdk.TokensFromConsensusPower(initialPower, sdk.DefaultPowerReduction)
+	initCoins  = sdk.NewCoins(sdk.NewCoin(bondDenom, initTokens))
+)
+
+var historacleTestCases = []struct {
+	exchangeRates        []string
+	expectedHistoricTWAP sdk.Dec
+}{
+	{
+		[]string{"1.0", "1.2", "1.1", "1.4", "1.1", "1.15",
+			"1.2", "1.3", "1.2", "1.12", "1.2", "1.15"},
+		sdk.MustNewDecFromStr("1.175"), // TWAP[0, 11]
+	},
+	{
+		[]string{"2.3", "2.12", "2.14", "2.24", "2.18", "2.15",
+			"2.51", "2.59", "2.67", "2.76", "2.89", "2.85"},
+		sdk.MustNewDecFromStr("2.405"), // TWAP[0, 11]
+	},
+}
+
+func (s *IntegrationTestSuite) TestEndblockerHistoracle() {
+	app, ctx := s.app, s.ctx
+
+	// update historacle params
+	// newOracleParams := types.DefaultParams()
+	// app.OracleKeeper.SetParams(ctx, newOracleParams)
+
+	for _, tc := range historacleTestCases {
+		// startTimeStamp := time.Now().UTC() // store timestamp before insertions
+
+		ctx = ctx.WithBlockHeight(ctx.BlockHeight() + int64(app.OracleKeeper.GetParams(ctx).VotePeriod-1))
+		ctx = ctx.WithBlockTime(time.Now().UTC())
+
+		// check if last price is updated after each vote period
+		for _, exchangeRate := range tc.exchangeRates {
+			var tuples types.ExchangeRateTuples
+			for _, denom := range app.OracleKeeper.AcceptList(ctx) {
+				tuples = append(tuples, types.ExchangeRateTuple{
+					Denom:        denom.SymbolDenom,
+					ExchangeRate: sdk.MustNewDecFromStr(exchangeRate),
+				})
+			}
+
+			prevote := types.AggregateExchangeRatePrevote{
+				Hash:        "hash",
+				Voter:       valAddr.String(),
+				SubmitBlock: uint64(ctx.BlockHeight()),
+			}
+			app.OracleKeeper.SetAggregateExchangeRatePrevote(ctx, valAddr, prevote)
+			oracle.EndBlocker(ctx, app.OracleKeeper)
+
+			ctx = ctx.WithBlockHeight(ctx.BlockHeight() + int64(app.OracleKeeper.VotePeriod(ctx)))
+			ctx = ctx.WithBlockTime(time.Now().UTC())
+
+			vote := types.AggregateExchangeRateVote{
+				ExchangeRateTuples: tuples,
+				Voter:              valAddr.String(),
+			}
+			app.OracleKeeper.SetAggregateExchangeRateVote(ctx, valAddr, vote)
+
+			oracle.EndBlocker(ctx, app.OracleKeeper)
+
+			for _, denom := range app.OracleKeeper.AcceptList(ctx) {
+				readExchangeRate, err := app.OracleKeeper.GetExchangeRate(ctx, denom.SymbolDenom)
+				s.Require().NoError(err)
+				s.Require().Equal(sdk.MustNewDecFromStr(exchangeRate), readExchangeRate)
+			}
+		}
+
+		// TODO: test below is throwing "no values in range"
+		// because there is no exchangeRate entry before startTimeStamp
+		// which is a case that can happen and should be fixed in history.go
+
+		// // historical TWAP
+		// for _, denom := range app.OracleKeeper.AcceptList(ctx) {
+		// 	// query for TWAP of all entered exchangeRates
+		// 	twap, err := app.OracleKeeper.GetArithmetricTWAP(ctx, denom.SymbolDenom, startTimeStamp, time.Now().UTC())
+		// 	s.Require().NoError(err)
+		// 	s.Require().Equal(tc.expectedHistoricTWAP, twap)
+		// }
+
+		// historical prices query
+
+		ctx = ctx.WithBlockHeight(0)
+		ctx = ctx.WithBlockTime(time.Now().UTC())
+	}
+}
+
+func TestOracleTestSuite(t *testing.T) {
+	suite.Run(t, new(IntegrationTestSuite))
+}

--- a/x/oracle/keeper/history_test.go
+++ b/x/oracle/keeper/history_test.go
@@ -154,3 +154,231 @@ func TestRemoveHistoryEntryBeforeTime(t *testing.T) {
 	require.Equal(t, 1, len(phStores))
 	require.Equal(t, phStores[0], phEntrys[2])
 }
+
+func TestStoreAndGetMultipleHistoricalData(t *testing.T) {
+	timeNow := time.Now().UTC()
+	ctx, keepers := CreateTestInput(t, false)
+	oracleKeeper := keepers.OracleKeeper
+
+	phEntrysDenom := []types.PriceHistoryEntry{
+		{
+			Price:           sdk.OneDec(),
+			VotePeriodCount: 10,
+			PriceUpdateTime: timeNow,
+		},
+		{
+			Price:           sdk.OneDec(),
+			VotePeriodCount: 11,
+			PriceUpdateTime: timeNow.Add(time.Minute * 2),
+		},
+		{
+			Price:           sdk.OneDec(),
+			VotePeriodCount: 12,
+			PriceUpdateTime: timeNow.Add(time.Minute * 4),
+		},
+	}
+	for _, phEntry := range phEntrysDenom {
+		oracleKeeper.storeHistoricalData(ctx, "Denom", phEntry)
+	}
+
+	phEntrysDen := []types.PriceHistoryEntry{
+		{
+			Price:           sdk.OneDec(),
+			VotePeriodCount: 100,
+			PriceUpdateTime: timeNow,
+		},
+		{
+			Price:           sdk.OneDec(),
+			VotePeriodCount: 101,
+			PriceUpdateTime: timeNow.Add(time.Minute * 2),
+		},
+		{
+			Price:           sdk.OneDec(),
+			VotePeriodCount: 102,
+			PriceUpdateTime: timeNow.Add(time.Minute * 6),
+		},
+	}
+	for _, phEntry := range phEntrysDen {
+		oracleKeeper.storeHistoricalData(ctx, "Den", phEntry)
+	}
+
+	phEntrysJuno := []types.PriceHistoryEntry{
+		{
+			Price:           sdk.OneDec(),
+			VotePeriodCount: 20,
+			PriceUpdateTime: timeNow,
+		},
+		{
+			Price:           sdk.OneDec(),
+			VotePeriodCount: 21,
+			PriceUpdateTime: timeNow.Add(time.Minute * 3),
+		},
+		{
+			Price:           sdk.OneDec(),
+			VotePeriodCount: 22,
+			PriceUpdateTime: timeNow.Add(time.Minute * 9),
+		},
+	}
+	for _, phEntry := range phEntrysJuno {
+		oracleKeeper.storeHistoricalData(ctx, "JUNO", phEntry)
+	}
+
+	// checks for token with denom: "Denom"
+	phStoreDenom, err := oracleKeeper.getHistoryEntryAtOrBeforeTime(ctx, "Denom", phEntrysDenom[0].PriceUpdateTime.Add(-time.Minute))
+	require.Error(t, err)
+	require.Equal(t, types.PriceHistoryEntry{}, phStoreDenom)
+	phStoreDenom, err = oracleKeeper.getHistoryEntryAtOrBeforeTime(ctx, "Denom", phEntrysDenom[0].PriceUpdateTime)
+	require.NoError(t, err)
+	require.Equal(t, phEntrysDenom[0], phStoreDenom)
+	phStoreDenom, err = oracleKeeper.getHistoryEntryAtOrBeforeTime(ctx, "Denom", phEntrysDenom[0].PriceUpdateTime.Add(time.Minute))
+	require.NoError(t, err)
+	require.Equal(t, phEntrysDenom[0], phStoreDenom)
+	phStoreDenom, err = oracleKeeper.getHistoryEntryAtOrBeforeTime(ctx, "Denom", phEntrysDenom[1].PriceUpdateTime)
+	require.NoError(t, err)
+	require.Equal(t, phEntrysDenom[1], phStoreDenom)
+	phStoreDenom, err = oracleKeeper.getHistoryEntryAtOrBeforeTime(ctx, "Denom", phEntrysDenom[1].PriceUpdateTime.Add(time.Minute))
+	require.NoError(t, err)
+	require.Equal(t, phEntrysDenom[1], phStoreDenom)
+
+	phStoresDenom, err := oracleKeeper.getHistoryEntryBetweenTime(
+		ctx,
+		"Denom",
+		phEntrysDenom[0].PriceUpdateTime.Add(-time.Minute),
+		phEntrysDenom[2].PriceUpdateTime.Add(time.Minute),
+	)
+	require.NoError(t, err)
+	require.Equal(t, phStoresDenom, phEntrysDenom)
+
+	phStoresDenom, err = oracleKeeper.getHistoryEntryBetweenTime(
+		ctx,
+		"Denom",
+		phEntrysDenom[0].PriceUpdateTime.Add(-time.Minute),
+		phEntrysDenom[1].PriceUpdateTime,
+	)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(phStoresDenom))
+	require.Equal(t, phStoresDenom[0], phEntrysDenom[0])
+	require.Equal(t, phStoresDenom[1], phEntrysDenom[1])
+
+	// checks for token with denom: "Den"
+	phStoreDen, err := oracleKeeper.getHistoryEntryAtOrBeforeTime(ctx, "Den", phEntrysDen[0].PriceUpdateTime.Add(-time.Minute))
+	require.Error(t, err)
+	require.Equal(t, types.PriceHistoryEntry{}, phStoreDen)
+	phStoreDen, err = oracleKeeper.getHistoryEntryAtOrBeforeTime(ctx, "Den", phEntrysDen[0].PriceUpdateTime)
+	require.NoError(t, err)
+	require.Equal(t, phEntrysDen[0], phStoreDen)
+	phStoreDen, err = oracleKeeper.getHistoryEntryAtOrBeforeTime(ctx, "Den", phEntrysDen[0].PriceUpdateTime.Add(time.Minute))
+	require.NoError(t, err)
+	require.Equal(t, phEntrysDen[0], phStoreDen)
+	phStoreDen, err = oracleKeeper.getHistoryEntryAtOrBeforeTime(ctx, "Den", phEntrysDen[1].PriceUpdateTime)
+	require.NoError(t, err)
+	require.Equal(t, phEntrysDen[1], phStoreDen)
+	phStoreDen, err = oracleKeeper.getHistoryEntryAtOrBeforeTime(ctx, "Den", phEntrysDen[1].PriceUpdateTime.Add(time.Minute))
+	require.NoError(t, err)
+	require.Equal(t, phEntrysDen[1], phStoreDen)
+
+	phStoresDen, err := oracleKeeper.getHistoryEntryBetweenTime(
+		ctx,
+		"Den",
+		phEntrysDen[0].PriceUpdateTime.Add(-time.Minute),
+		phEntrysDen[2].PriceUpdateTime.Add(time.Minute),
+	)
+	require.NoError(t, err)
+	require.Equal(t, phStoresDen, phEntrysDen)
+
+	phStoresDen, err = oracleKeeper.getHistoryEntryBetweenTime(
+		ctx,
+		"Den",
+		phEntrysDen[0].PriceUpdateTime.Add(-time.Minute),
+		phEntrysDen[1].PriceUpdateTime,
+	)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(phStoresDen))
+	require.Equal(t, phStoresDen[0], phEntrysDen[0])
+	require.Equal(t, phStoresDen[1], phEntrysDen[1])
+
+	// checks for token with denom: "Juno"
+	phStoreJuno, err := oracleKeeper.getHistoryEntryAtOrBeforeTime(ctx, "Juno", phEntrysJuno[0].PriceUpdateTime.Add(-time.Minute))
+	require.Error(t, err)
+	require.Equal(t, types.PriceHistoryEntry{}, phStoreJuno)
+	phStoreJuno, err = oracleKeeper.getHistoryEntryAtOrBeforeTime(ctx, "Juno", phEntrysJuno[0].PriceUpdateTime)
+	require.NoError(t, err)
+	require.Equal(t, phEntrysJuno[0], phStoreJuno)
+	phStoreJuno, err = oracleKeeper.getHistoryEntryAtOrBeforeTime(ctx, "Juno", phEntrysJuno[0].PriceUpdateTime.Add(time.Minute))
+	require.NoError(t, err)
+	require.Equal(t, phEntrysJuno[0], phStoreJuno)
+	phStoreJuno, err = oracleKeeper.getHistoryEntryAtOrBeforeTime(ctx, "Juno", phEntrysJuno[1].PriceUpdateTime)
+	require.NoError(t, err)
+	require.Equal(t, phEntrysJuno[1], phStoreJuno)
+	phStoreJuno, err = oracleKeeper.getHistoryEntryAtOrBeforeTime(ctx, "Juno", phEntrysJuno[1].PriceUpdateTime.Add(time.Minute))
+	require.NoError(t, err)
+	require.Equal(t, phEntrysJuno[1], phStoreJuno)
+
+	phStoresdjuno, err := oracleKeeper.getHistoryEntryBetweenTime(
+		ctx,
+		"Juno",
+		phEntrysJuno[0].PriceUpdateTime.Add(-time.Minute),
+		phEntrysJuno[2].PriceUpdateTime.Add(time.Minute),
+	)
+	require.NoError(t, err)
+	require.Equal(t, phStoresdjuno, phEntrysJuno)
+
+	phStoresdjuno, err = oracleKeeper.getHistoryEntryBetweenTime(
+		ctx,
+		"Juno",
+		phEntrysJuno[0].PriceUpdateTime.Add(-time.Minute),
+		phEntrysJuno[1].PriceUpdateTime,
+	)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(phStoresdjuno))
+	require.Equal(t, phStoresdjuno[0], phEntrysJuno[0])
+	require.Equal(t, phStoresdjuno[1], phEntrysJuno[1])
+}
+
+func TestStoreAndGetNullHistoricalData(t *testing.T) {
+	timeNow := time.Now().UTC()
+	ctx, keepers := CreateTestInput(t, false)
+	oracleKeeper := keepers.OracleKeeper
+
+	phEntrys := []types.PriceHistoryEntry{
+		{
+			Price:           sdk.OneDec(),
+			VotePeriodCount: 10,
+			PriceUpdateTime: timeNow,
+		},
+		{
+			Price:           sdk.OneDec(),
+			VotePeriodCount: 11,
+			PriceUpdateTime: timeNow.Add(time.Minute * 2),
+		},
+		{
+			Price:           sdk.OneDec(),
+			VotePeriodCount: 12,
+			PriceUpdateTime: timeNow.Add(time.Minute * 4),
+		},
+	}
+
+	for _, phEntry := range phEntrys {
+		oracleKeeper.storeHistoricalData(ctx, "Denom", phEntry)
+	}
+
+	// below queries should all throw error as "Juno" denom does not exist
+	phStore, err := oracleKeeper.getHistoryEntryAtOrBeforeTime(ctx, "Juno", phEntrys[0].PriceUpdateTime.Add(-time.Minute))
+	require.Error(t, err)
+	require.Equal(t, types.PriceHistoryEntry{}, phStore)
+	phStore, err = oracleKeeper.getHistoryEntryAtOrBeforeTime(ctx, "Juno", phEntrys[0].PriceUpdateTime)
+	require.Error(t, err)
+	require.Equal(t, types.PriceHistoryEntry{}, phStore)
+	phStore, err = oracleKeeper.getHistoryEntryAtOrBeforeTime(ctx, "Juno", phEntrys[1].PriceUpdateTime)
+	require.Error(t, err)
+	require.Equal(t, types.PriceHistoryEntry{}, phStore)
+
+	phStores, err := oracleKeeper.getHistoryEntryBetweenTime(
+		ctx,
+		"Juno",
+		phEntrys[0].PriceUpdateTime.Add(-time.Minute),
+		phEntrys[2].PriceUpdateTime.Add(time.Minute),
+	)
+	require.NoError(t, err) // To discuss: should this throw error?
+	require.Equal(t, []types.PriceHistoryEntry(nil), phStores)
+}


### PR DESCRIPTION
1. Adds price history test for when we have multiple denominations (one denom is prefix of another also covered), to make sure that multiple denom entries does not interfere with each other.
2. Adds price history test for when price is queried for denom which hasn't been stored yet.
3. Adds abci tests for EndBlocker to see if price is correctly stored after validator vote period is over.

To discuss:
1. `getHistoryEntryBetweenTime()` returns `[]types.PriceHistoryEntry(nil)` instead of `[]types.PriceHistoryEntry{}` when the denom does not have stored prices. Is it expected or should be changed?
2. `GetArithmetricTWAP()` throws errror `no values in range` when there is no price entry for given denom before `startTime` becuase the first and last price entry is fetched using `getHistoryEntryAtOrBeforeTime()` and it throws error for `startTime`. IMO this should be handled in `GetArithmetricTWAP()` and values must be returned even if there is no price entry before `startTime`.
3. I've left TODO in comments for both of the above.