### PR TITLE
old [v12] Set Globalfees on upgrade, cleanup

### DIFF
--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -71,6 +71,7 @@ import (
 	icacontrollertypes "github.com/cosmos/ibc-go/v4/modules/apps/27-interchain-accounts/controller/types"
 
 	"github.com/cosmos/gaia/v8/x/globalfee"
+	globalfeetypes "github.com/cosmos/gaia/v8/x/globalfee/types"
 	intertxkeeper "github.com/cosmos/interchain-accounts/x/inter-tx/keeper"
 	intertxtypes "github.com/cosmos/interchain-accounts/x/inter-tx/types"
 )
@@ -442,7 +443,7 @@ func initParamsKeeper(appCodec codec.BinaryCodec, legacyAmino *codec.LegacyAmino
 	paramsKeeper.Subspace(icahosttypes.SubModuleName)
 	paramsKeeper.Subspace(wasm.ModuleName)
 	paramsKeeper.Subspace(tokenfactorytypes.ModuleName)
-	paramsKeeper.Subspace(globalfee.ModuleName)
+	paramsKeeper.Subspace(globalfee.ModuleName).WithKeyTable(globalfeetypes.ParamKeyTable())
 	paramsKeeper.Subspace(feesharetypes.ModuleName)
 
 	return paramsKeeper

--- a/app/upgrades/v12/upgrades.go
+++ b/app/upgrades/v12/upgrades.go
@@ -23,6 +23,8 @@ import (
 
 	ica "github.com/cosmos/ibc-go/v4/modules/apps/27-interchain-accounts"
 	ibcfeetypes "github.com/cosmos/ibc-go/v4/modules/apps/29-fee/types"
+
+	globalfeetypes "github.com/cosmos/gaia/v8/x/globalfee/types"
 )
 
 // Returns "ujuno" if the chainID starts with "juno-" (ex: juno-1 or juno-t1 for local)
@@ -66,6 +68,20 @@ func CreateV12UpgradeHandler(
 		controllerParams := icacontrollertypes.Params{
 			ControllerEnabled: true,
 		}
+
+		// GlobalFee
+		defaultFee := sdk.DecCoins{
+			// 0.025ujuno
+			sdk.NewDecCoinFromDec(nativeDenom, sdk.NewDecWithPrec(25, 3)),
+		}
+
+		globalfeeState := globalfeetypes.GenesisState{
+			Params: globalfeetypes.Params{
+				MinimumGasPrices: defaultFee,
+			},
+		}
+
+		keepers.ParamsKeeper.Subspace(globalfeetypes.ModuleName).Set(ctx, globalfeetypes.ParamStoreKeyMinGasPrices, globalfeeState.Params)
 
 		// create ICS27 Host submodule params
 		hostParams := icahosttypes.Params{

--- a/app/upgrades/v12/upgrades.go
+++ b/app/upgrades/v12/upgrades.go
@@ -1,6 +1,7 @@
 package v12
 
 import (
+	"fmt"
 	"strings"
 
 	tokenfactorytypes "github.com/CosmWasm/token-factory/x/tokenfactory/types"
@@ -25,6 +26,9 @@ import (
 	ibcfeetypes "github.com/cosmos/ibc-go/v4/modules/apps/29-fee/types"
 
 	globalfeetypes "github.com/cosmos/gaia/v8/x/globalfee/types"
+
+	// tendermint logger
+	tmlog "github.com/tendermint/tendermint/libs/log"
 )
 
 // Returns "ujuno" if the chainID starts with "juno-" (ex: juno-1 or juno-t1 for local)
@@ -43,102 +47,129 @@ func CreateV12UpgradeHandler(
 	keepers *keepers.AppKeepers,
 ) upgradetypes.UpgradeHandler {
 	return func(ctx sdk.Context, _ upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
-		nativeDenom := GetChainsDenomToken(ctx.ChainID())
 		// transfer module consensus version has been bumped to 2
 		// the above is https://github.com/cosmos/ibc-go/blob/v5.1.0/docs/migrations/v3-to-v4.md
+		logger := ctx.Logger().With("upgrade", UpgradeName)
 
-		// TokenFactory
-		newTokenFactoryParams := tokenfactorytypes.Params{
-			DenomCreationFee: sdk.NewCoins(sdk.NewCoin(nativeDenom, sdk.NewInt(1000000))),
-		}
-		keepers.TokenFactoryKeeper.SetParams(ctx, newTokenFactoryParams)
+		nativeDenom := GetChainsDenomToken(ctx.ChainID())
+		logger.Info(fmt.Sprintf("With native denom %s", nativeDenom))
 
-		// FeeShare
-		newFeeShareParams := feesharetypes.Params{
-			EnableFeeShare:  true,
-			DeveloperShares: sdk.NewDecWithPrec(50, 2), // = 50%
-			AllowedDenoms:   []string{nativeDenom},
-		}
-		keepers.FeeShareKeeper.SetParams(ctx, newFeeShareParams)
+		upgradeTokenFactory(ctx, logger, nativeDenom, keepers)
+		upgradeFeeShare(ctx, logger, nativeDenom, keepers)
+		upgradeICAModule(ctx, logger, nativeDenom, keepers, vm, mm)
+		upgradeIBCFee(ctx, logger, nativeDenom, keepers, vm, mm)
 
-		// ICA - https://github.com/CosmosContracts/juno/blob/integrate_ica_changes/app/app.go#L846-L885
-		vm[icatypes.ModuleName] = mm.Modules[icatypes.ModuleName].ConsensusVersion()
+		// Run migrations
+		versionMap, err := mm.RunMigrations(ctx, cfg, vm)
 
-		// create ICS27 Controller submodule params, controller module not enabled.
-		controllerParams := icacontrollertypes.Params{
-			ControllerEnabled: true,
-		}
+		// GlobalFee must run after migrations to update the param space set by default
+		upgradeGlobalFee(ctx, logger, nativeDenom, keepers)
 
-		// GlobalFee
-		defaultFee := sdk.DecCoins{
-			// 0.025ujuno
-			sdk.NewDecCoinFromDec(nativeDenom, sdk.NewDecWithPrec(25, 3)),
-		}
-
-		globalfeeState := globalfeetypes.GenesisState{
-			Params: globalfeetypes.Params{
-				MinimumGasPrices: defaultFee,
-			},
-		}
-
-		keepers.ParamsKeeper.Subspace(globalfeetypes.ModuleName).Set(ctx, globalfeetypes.ParamStoreKeyMinGasPrices, globalfeeState.Params)
-
-		// create ICS27 Host submodule params
-		hostParams := icahosttypes.Params{
-			HostEnabled: true,
-			AllowMessages: []string{
-				sdk.MsgTypeURL(&banktypes.MsgSend{}),
-				sdk.MsgTypeURL(&banktypes.MsgMultiSend{}),
-				sdk.MsgTypeURL(&stakingtypes.MsgDelegate{}),
-				sdk.MsgTypeURL(&stakingtypes.MsgBeginRedelegate{}),
-				sdk.MsgTypeURL(&stakingtypes.MsgUndelegate{}),
-				sdk.MsgTypeURL(&stakingtypes.MsgCreateValidator{}),
-				sdk.MsgTypeURL(&stakingtypes.MsgEditValidator{}),
-				sdk.MsgTypeURL(&distrtypes.MsgWithdrawDelegatorReward{}),
-				sdk.MsgTypeURL(&distrtypes.MsgSetWithdrawAddress{}),
-				sdk.MsgTypeURL(&distrtypes.MsgWithdrawValidatorCommission{}),
-				sdk.MsgTypeURL(&distrtypes.MsgFundCommunityPool{}),
-				sdk.MsgTypeURL(&govtypes.MsgVote{}),
-				sdk.MsgTypeURL(&govtypes.MsgVoteWeighted{}),
-				sdk.MsgTypeURL(&govtypes.MsgSubmitProposal{}),
-				sdk.MsgTypeURL(&govtypes.MsgDeposit{}),
-				sdk.MsgTypeURL(&authz.MsgExec{}),
-				sdk.MsgTypeURL(&authz.MsgGrant{}),
-				sdk.MsgTypeURL(&authz.MsgRevoke{}),
-				// wasm
-				sdk.MsgTypeURL(&wasmtypes.MsgStoreCode{}),
-				sdk.MsgTypeURL(&wasmtypes.MsgInstantiateContract{}),
-				sdk.MsgTypeURL(&wasmtypes.MsgInstantiateContract2{}),
-				sdk.MsgTypeURL(&wasmtypes.MsgExecuteContract{}),
-				sdk.MsgTypeURL(&wasmtypes.MsgMigrateContract{}),
-				sdk.MsgTypeURL(&wasmtypes.MsgUpdateAdmin{}),
-				sdk.MsgTypeURL(&wasmtypes.MsgClearAdmin{}),
-				sdk.MsgTypeURL(&wasmtypes.MsgIBCSend{}),
-				sdk.MsgTypeURL(&wasmtypes.MsgIBCCloseChannel{}),
-				// tokenfactory
-				sdk.MsgTypeURL(&tokenfactorytypes.MsgCreateDenom{}),
-				sdk.MsgTypeURL(&tokenfactorytypes.MsgMint{}),
-				sdk.MsgTypeURL(&tokenfactorytypes.MsgBurn{}),
-				sdk.MsgTypeURL(&tokenfactorytypes.MsgChangeAdmin{}),
-				sdk.MsgTypeURL(&tokenfactorytypes.MsgSetDenomMetadata{}),
-				// feeshare
-				sdk.MsgTypeURL(&feesharetypes.MsgRegisterFeeShare{}),
-				sdk.MsgTypeURL(&feesharetypes.MsgUpdateFeeShare{}),
-				sdk.MsgTypeURL(&feesharetypes.MsgUpdateFeeShare{}),
-				sdk.MsgTypeURL(&feesharetypes.MsgCancelFeeShare{}),
-			},
-		}
-
-		// initialize ICS27 module
-		icamodule, correctTypecast := mm.Modules[icatypes.ModuleName].(ica.AppModule)
-		if !correctTypecast {
-			panic("mm.Modules[icatypes.ModuleName] is not of type ica.AppModule")
-		}
-		icamodule.InitModule(ctx, controllerParams, hostParams)
-
-		// IBCFee
-		vm[ibcfeetypes.ModuleName] = mm.Modules[ibcfeetypes.ModuleName].ConsensusVersion()
-
-		return mm.RunMigrations(ctx, cfg, vm)
+		return versionMap, err
 	}
+}
+
+func upgradeIBCFee(ctx sdk.Context, logger tmlog.Logger, nativeDenom string, keepers *keepers.AppKeepers, vm module.VersionMap, mm *module.Manager) {
+	// IBCFee
+	vm[ibcfeetypes.ModuleName] = mm.Modules[ibcfeetypes.ModuleName].ConsensusVersion()
+	logger.Info(fmt.Sprintf("ibcfee module version %s set", fmt.Sprint(vm[ibcfeetypes.ModuleName])))
+}
+
+func upgradeTokenFactory(ctx sdk.Context, logger tmlog.Logger, nativeDenom string, keepers *keepers.AppKeepers) {
+	newTokenFactoryParams := tokenfactorytypes.Params{
+		DenomCreationFee: sdk.NewCoins(sdk.NewCoin(nativeDenom, sdk.NewInt(1000000))),
+	}
+	keepers.TokenFactoryKeeper.SetParams(ctx, newTokenFactoryParams)
+	logger.Info("upgraded token factory params")
+}
+
+func upgradeFeeShare(ctx sdk.Context, logger tmlog.Logger, nativeDenom string, keepers *keepers.AppKeepers) {
+	newFeeShareParams := feesharetypes.Params{
+		EnableFeeShare:  true,
+		DeveloperShares: sdk.NewDecWithPrec(50, 2), // = 50%
+		AllowedDenoms:   []string{nativeDenom},
+	}
+	keepers.FeeShareKeeper.SetParams(ctx, newFeeShareParams)
+	logger.Info("upgraded fee share params")
+}
+
+func upgradeGlobalFee(ctx sdk.Context, logger tmlog.Logger, nativeDenom string, keepers *keepers.AppKeepers) {
+	// This must run AFTER migrations to update the default param space.
+	minGasPrices := sdk.DecCoins{
+		// 0.0025ujuno
+		sdk.NewDecCoinFromDec(nativeDenom, sdk.NewDecWithPrec(25, 4)),
+		// 0.001 ATOM CHANNEL-1 -> `junod q ibc-transfer denom-trace ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9`
+		sdk.NewDecCoinFromDec("ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9", sdk.NewDecWithPrec(1, 4)),
+	}
+	s, ok := keepers.ParamsKeeper.GetSubspace(globalfeetypes.ModuleName)
+	if !ok {
+		panic("global fee params subspace not found")
+	}
+	s.Set(ctx, globalfeetypes.ParamStoreKeyMinGasPrices, minGasPrices)
+	logger.Info(fmt.Sprintf("upgraded global fee params to %s", minGasPrices))
+}
+
+func upgradeICAModule(ctx sdk.Context, logger tmlog.Logger, nativeDenom string, keepers *keepers.AppKeepers, vm module.VersionMap, mm *module.Manager) {
+	// ICA - https://github.com/CosmosContracts/juno/blob/integrate_ica_changes/app/app.go#L846-L885
+	vm[icatypes.ModuleName] = mm.Modules[icatypes.ModuleName].ConsensusVersion()
+	logger.Info(fmt.Sprintf("upgraded ICA module version %s", fmt.Sprint(vm[icatypes.ModuleName])))
+
+	// create ICS27 Controller submodule params with controller module enabled.
+	controllerParams := icacontrollertypes.Params{
+		ControllerEnabled: true,
+	}
+
+	// create ICS27 Host submodule params
+	hostParams := icahosttypes.Params{
+		HostEnabled: true,
+		AllowMessages: []string{
+			sdk.MsgTypeURL(&banktypes.MsgSend{}),
+			sdk.MsgTypeURL(&banktypes.MsgMultiSend{}),
+			sdk.MsgTypeURL(&stakingtypes.MsgDelegate{}),
+			sdk.MsgTypeURL(&stakingtypes.MsgBeginRedelegate{}),
+			sdk.MsgTypeURL(&stakingtypes.MsgUndelegate{}),
+			sdk.MsgTypeURL(&stakingtypes.MsgCreateValidator{}),
+			sdk.MsgTypeURL(&stakingtypes.MsgEditValidator{}),
+			sdk.MsgTypeURL(&distrtypes.MsgWithdrawDelegatorReward{}),
+			sdk.MsgTypeURL(&distrtypes.MsgSetWithdrawAddress{}),
+			sdk.MsgTypeURL(&distrtypes.MsgWithdrawValidatorCommission{}),
+			sdk.MsgTypeURL(&distrtypes.MsgFundCommunityPool{}),
+			sdk.MsgTypeURL(&govtypes.MsgVote{}),
+			sdk.MsgTypeURL(&govtypes.MsgVoteWeighted{}),
+			sdk.MsgTypeURL(&govtypes.MsgSubmitProposal{}),
+			sdk.MsgTypeURL(&govtypes.MsgDeposit{}),
+			sdk.MsgTypeURL(&authz.MsgExec{}),
+			sdk.MsgTypeURL(&authz.MsgGrant{}),
+			sdk.MsgTypeURL(&authz.MsgRevoke{}),
+			// wasm
+			sdk.MsgTypeURL(&wasmtypes.MsgStoreCode{}),
+			sdk.MsgTypeURL(&wasmtypes.MsgInstantiateContract{}),
+			sdk.MsgTypeURL(&wasmtypes.MsgInstantiateContract2{}),
+			sdk.MsgTypeURL(&wasmtypes.MsgExecuteContract{}),
+			sdk.MsgTypeURL(&wasmtypes.MsgMigrateContract{}),
+			sdk.MsgTypeURL(&wasmtypes.MsgUpdateAdmin{}),
+			sdk.MsgTypeURL(&wasmtypes.MsgClearAdmin{}),
+			sdk.MsgTypeURL(&wasmtypes.MsgIBCSend{}),
+			sdk.MsgTypeURL(&wasmtypes.MsgIBCCloseChannel{}),
+			// tokenfactory
+			sdk.MsgTypeURL(&tokenfactorytypes.MsgCreateDenom{}),
+			sdk.MsgTypeURL(&tokenfactorytypes.MsgMint{}),
+			sdk.MsgTypeURL(&tokenfactorytypes.MsgBurn{}),
+			sdk.MsgTypeURL(&tokenfactorytypes.MsgChangeAdmin{}),
+			sdk.MsgTypeURL(&tokenfactorytypes.MsgSetDenomMetadata{}),
+			// feeshare
+			sdk.MsgTypeURL(&feesharetypes.MsgRegisterFeeShare{}),
+			sdk.MsgTypeURL(&feesharetypes.MsgUpdateFeeShare{}),
+			sdk.MsgTypeURL(&feesharetypes.MsgUpdateFeeShare{}),
+			sdk.MsgTypeURL(&feesharetypes.MsgCancelFeeShare{}),
+		},
+	}
+
+	// initialize ICS27 module
+	icamodule, correctTypecast := mm.Modules[icatypes.ModuleName].(ica.AppModule)
+	if !correctTypecast {
+		panic("mm.Modules[icatypes.ModuleName] is not of type ica.AppModule")
+	}
+	icamodule.InitModule(ctx, controllerParams, hostParams)
+	logger.Info(fmt.Sprintf("icamodule initialized"))
 }

--- a/app/upgrades/v12/upgrades.go
+++ b/app/upgrades/v12/upgrades.go
@@ -56,8 +56,8 @@ func CreateV12UpgradeHandler(
 
 		upgradeTokenFactory(ctx, logger, nativeDenom, keepers)
 		upgradeFeeShare(ctx, logger, nativeDenom, keepers)
-		upgradeICAModule(ctx, logger, nativeDenom, keepers, vm, mm)
-		upgradeIBCFee(ctx, logger, nativeDenom, keepers, vm, mm)
+		upgradeICAModule(ctx, logger, vm, mm)
+		upgradeIBCFee(logger, vm, mm)
 
 		// Run migrations
 		versionMap, err := mm.RunMigrations(ctx, cfg, vm)
@@ -69,7 +69,7 @@ func CreateV12UpgradeHandler(
 	}
 }
 
-func upgradeIBCFee(ctx sdk.Context, logger tmlog.Logger, nativeDenom string, keepers *keepers.AppKeepers, vm module.VersionMap, mm *module.Manager) {
+func upgradeIBCFee(logger tmlog.Logger, vm module.VersionMap, mm *module.Manager) {
 	// IBCFee
 	vm[ibcfeetypes.ModuleName] = mm.Modules[ibcfeetypes.ModuleName].ConsensusVersion()
 	logger.Info(fmt.Sprintf("ibcfee module version %s set", fmt.Sprint(vm[ibcfeetypes.ModuleName])))
@@ -109,7 +109,7 @@ func upgradeGlobalFee(ctx sdk.Context, logger tmlog.Logger, nativeDenom string, 
 	logger.Info(fmt.Sprintf("upgraded global fee params to %s", minGasPrices))
 }
 
-func upgradeICAModule(ctx sdk.Context, logger tmlog.Logger, nativeDenom string, keepers *keepers.AppKeepers, vm module.VersionMap, mm *module.Manager) {
+func upgradeICAModule(ctx sdk.Context, logger tmlog.Logger, vm module.VersionMap, mm *module.Manager) {
 	// ICA - https://github.com/CosmosContracts/juno/blob/integrate_ica_changes/app/app.go#L846-L885
 	vm[icatypes.ModuleName] = mm.Modules[icatypes.ModuleName].ConsensusVersion()
 	logger.Info(fmt.Sprintf("upgraded ICA module version %s", fmt.Sprint(vm[icatypes.ModuleName])))
@@ -171,5 +171,5 @@ func upgradeICAModule(ctx sdk.Context, logger tmlog.Logger, nativeDenom string, 
 		panic("mm.Modules[icatypes.ModuleName] is not of type ica.AppModule")
 	}
 	icamodule.InitModule(ctx, controllerParams, hostParams)
-	logger.Info(fmt.Sprintf("icamodule initialized"))
+	logger.Info("icamodule initialized")
 }


### PR DESCRIPTION
Set min fees on upgrade AND cleanup upgrades into individual functions

Local Upgrade
```
3:38PM INF applying upgrade "v12" at height: 6
3:38PM INF With native denom ujuno upgrade=v12
3:38PM INF upgraded token factory params upgrade=v12
3:38PM INF upgraded fee share params upgrade=v12
3:38PM INF upgraded ICA module version 1 upgrade=v12
3:38PM INF created new capability module=ibc name=ports/icahost
3:38PM INF port binded module=x/ibc/port port=icahost
3:38PM INF claimed capability capability=3 module=icahost name=ports/icahost
3:38PM INF icamodule initialized upgrade=v12
3:38PM INF ibcfee module version 1 set upgrade=v12
3:38PM INF adding a new module: feeshare
3:38PM INF adding a new module: globalfee
3:38PM INF adding a new module: intertx
3:38PM INF adding a new module: tokenfactory
3:38PM INF migrating module wasm from version 1 to version 2
3:38PM INF upgraded global fee params to 0.002500000000000000ujuno,0.000100000000000000ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9 upgrade=v12
3:38PM INF executed block height=6 module=consensus num_invalid_txs=0 num_valid_txs=0
```

```
junod q globalfee minimum-gas-prices --node http://localhost:26657
minimum_gas_prices:
- amount: "0.002500000000000000"
  denom: ujuno
- amount: "0.000100000000000000"
  denom: ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9
  ```