### PR TITLE
Update test for TWAP when startTime before first entry

### DIFF
--- a/x/oracle/keeper/grpc_query_test.go
+++ b/x/oracle/keeper/grpc_query_test.go
@@ -477,13 +477,16 @@ func (s *IntegrationTestSuite) TestArithmeticTwapPriceBetweenTime() {
 			shouldErr: false,
 		},
 		{
-			desc: "Error - Start time before first entry",
+			desc: "Success - Start time before first entry",
 			req: &types.QueryArithmeticTwapPriceBetweenTime{
 				Denom:     "JUNO",
 				StartTime: timeNow.Add(-time.Minute),
 				EndTime:   timeNow.Add(4 * time.Minute),
 			},
-			shouldErr: true,
+			res: &types.QueryArithmeticTwapPriceBetweenTimeResponse{
+				TwapPrice: sdk.NewDecCoinFromDec("JUNO", sdk.OneDec()),
+			},
+			shouldErr: false,
 		},
 		{
 			desc: "Error - End time before start time",


### PR DESCRIPTION
TWAP now returns a value in place of error when start time is before first entry, so now test reflects that