### PR TITLE
Openapi without ignite

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -35,7 +35,7 @@ import (
 	upgradeclient "github.com/cosmos/cosmos-sdk/x/upgrade/client"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 	ibcclientclient "github.com/cosmos/ibc-go/v4/modules/core/02-client/client"
-	"github.com/ignite-hq/cli/ignite/pkg/openapiconsole"
+	"github.com/CosmosContracts/juno/v12/app/openapiconsole"
 	"github.com/spf13/cast"
 	abci "github.com/tendermint/tendermint/abci/types"
 	tmjson "github.com/tendermint/tendermint/libs/json"

--- a/app/app.go
+++ b/app/app.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/CosmosContracts/juno/v12/app/openapiconsole"
 	"github.com/CosmosContracts/juno/v12/docs"
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
@@ -35,7 +36,6 @@ import (
 	upgradeclient "github.com/cosmos/cosmos-sdk/x/upgrade/client"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 	ibcclientclient "github.com/cosmos/ibc-go/v4/modules/core/02-client/client"
-	"github.com/CosmosContracts/juno/v12/app/openapiconsole"
 	"github.com/spf13/cast"
 	abci "github.com/tendermint/tendermint/abci/types"
 	tmjson "github.com/tendermint/tendermint/libs/json"

--- a/app/openapiconsole/console.go
+++ b/app/openapiconsole/console.go
@@ -1,0 +1,25 @@
+package openapiconsole
+
+import (
+	"embed"
+	"html/template"
+	"net/http"
+)
+
+//go:embed index.tpl
+var index embed.FS
+
+// Handler returns an http handler that servers OpenAPI console for an OpenAPI spec at specURL.
+func Handler(title, specURL string) http.HandlerFunc {
+	t, _ := template.ParseFS(index, "index.tpl")
+
+	return func(w http.ResponseWriter, req *http.Request) {
+		t.Execute(w, struct { //nolint:errcheck
+			Title string
+			URL   string
+		}{
+			title,
+			specURL,
+		})
+	}
+}

--- a/app/openapiconsole/index.tpl
+++ b/app/openapiconsole/index.tpl
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <title>{{ .Title }}</title>
+        <link rel="stylesheet" type="text/css" href="//unpkg.com/swagger-ui-dist@3.40.0/swagger-ui.css" />
+        <link rel="icon" type="image/png" href="//unpkg.com/swagger-ui-dist@3.40.0/favicon-16x16.png" />
+    </head>
+    <body>
+        <div id="swagger-ui"></div>
+
+        <script src="//unpkg.com/swagger-ui-dist@3.40.0/swagger-ui-bundle.js"></script>
+        <script>
+            // init Swagger for faucet's openapi.yml.
+            window.onload = function() {
+              window.ui = SwaggerUIBundle({
+                url: {{ .URL }},
+                dom_id: "#swagger-ui",
+                deepLinking: true,
+                layout: "BaseLayout",
+              });
+            }
+        </script>
+    </body>
+</html>

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/gorilla/mux v1.8.0
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
-	github.com/ignite-hq/cli v0.22.1
 	github.com/osmosis-labs/osmosis/x/ibc-hooks v0.0.0-20230110104305-322e8478dbe8
 	github.com/prometheus/client_golang v1.14.0
 	github.com/spf13/cast v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -523,8 +523,6 @@ github.com/huin/goupnp v1.0.3-0.20220313090229-ca81a64b4204/go.mod h1:ZxNlw5WqJj
 github.com/huin/goutil v0.0.0-20170803182201-1ca381bf3150/go.mod h1:PpLOETDnJ0o3iZrZfqZzyLl6l7F3c6L1oWn7OICBi6o=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
-github.com/ignite-hq/cli v0.22.1 h1:87DQZrbmfM7pNp1HmKRZtxIFydPfYDZJofssRi3yr2E=
-github.com/ignite-hq/cli v0.22.1/go.mod h1:E2dM1v4Gy3tZv2X/iUQY/L7HBObBrC5rjajivIPhbWc=
 github.com/imdario/mergo v0.3.13 h1:lFzP57bqS/wsqKssCGmtLAb8A0wKjLGrve2q3PPVcBk=
 github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK2O4oXg=
 github.com/improbable-eng/grpc-web v0.15.0 h1:BN+7z6uNXZ1tQGcNAuaU1YjsLTApzkjt2tzCixLaUPQ=


### PR DESCRIPTION
Riffing on Reece's very cool work to tune up the openapi 
console, this PR moves that into juno so that there's no 
longer any need to import anything from ignite, land of 
consensus rugging
