### PR TITLE
feat(x/feeshare): Allow registering factory contracts

### DIFF
--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -399,9 +399,13 @@ func NewAppKeepers(
 
 	// Stargate Queries
 	accepted := wasmkeeper.AcceptedStargateQueries{
+		// ibc
 		"/ibc.core.client.v1.Query/ClientState":    &ibcclienttypes.QueryClientStateResponse{},
 		"/ibc.core.client.v1.Query/ConsensusState": &ibcclienttypes.QueryConsensusStateResponse{},
 		"/ibc.core.connection.v1.Query/Connection": &ibcconnectiontypes.QueryConnectionResponse{},
+
+		// governance
+		"/cosmos.gov.v1beta1.Query/Vote": &govtypes.QueryVoteResponse{},
 
 		// token factory
 		"/osmosis.tokenfactory.v1beta1.Query/Params":                 &tokenfactorytypes.QueryParamsResponse{},

--- a/x/feeshare/README.md
+++ b/x/feeshare/README.md
@@ -6,3 +6,9 @@ This module is a heavily modified fork of [evmos/x/revenue](https://github.com/e
 A big thanks go to the original authors.
 
 [FeeShare Spec](spec/README.md)
+
+---
+
+> [Register a Contract](spec/00_register.md)
+
+> [Update Conrtact Withdraw Address](spec/00_update.md)

--- a/x/feeshare/client/cli/tx.go
+++ b/x/feeshare/client/cli/tx.go
@@ -108,7 +108,7 @@ func NewCancelFeeShare() *cobra.Command {
 // address of a contract for fee distribution
 func NewUpdateFeeShare() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "update [contract_bech32] [",
+		Use:   "update [contract_bech32] [new_withdraw_bech32]",
 		Short: "Update withdrawer address for a contract registered for feeshare distribution.",
 		Long:  "Update withdrawer address for a contract registered for feeshare distribution. \nOnly the contract admin can update the withdrawer address.",
 		Args:  cobra.ExactArgs(2),

--- a/x/feeshare/keeper/msg_server.go
+++ b/x/feeshare/keeper/msg_server.go
@@ -21,18 +21,19 @@ func (k Keeper) GetIfContractWasCreatedFromFactory(ctx sdk.Context, contract sdk
 		return false
 	}
 
-	// No admin and the instantiation was a contract, its a factory contract
-	if len(info.Admin) == 0 && k.wasmKeeper.HasContractInfo(ctx, creator) {
-		return true
+	isFactoryContract := false
+
+	if len(info.Admin) == 0 {
+		isFactoryContract = k.wasmKeeper.HasContractInfo(ctx, creator)
+	} else {
+		admin, err := sdk.AccAddressFromBech32(info.Admin)
+		if err != nil {
+			return false
+		}
+		isFactoryContract = k.wasmKeeper.HasContractInfo(ctx, admin)
 	}
 
-	// if there is an admin and its a contract, its a factory contract
-	admin, err := sdk.AccAddressFromBech32(info.Admin)
-	if err != nil {
-		return false
-	}
-
-	return k.wasmKeeper.HasContractInfo(ctx, admin)
+	return isFactoryContract
 }
 
 // GetContractAdminOrCreatorAddress ensures the deployer is the contract's admin OR creator if no admin is set for all msg_server feeshare functions.

--- a/x/feeshare/keeper/msg_server_test.go
+++ b/x/feeshare/keeper/msg_server_test.go
@@ -111,6 +111,7 @@ func (s *IntegrationTestSuite) TestRegisterFeeShare() {
 	_ = s.FundAccount(s.ctx, sender, sdk.NewCoins(sdk.NewCoin("stake", sdk.NewInt(1_000_000))))
 
 	contractAddress := s.InstantiateContract(sender.String(), "")
+	contractAddress2 := s.InstantiateContract(contractAddress, contractAddress)
 
 	_, _, withdrawer := testdata.KeyTestPubAddr()
 
@@ -156,6 +157,26 @@ func (s *IntegrationTestSuite) TestRegisterFeeShare() {
 				ContractAddress:   contractAddress,
 				DeployerAddress:   sender.String(),
 				WithdrawerAddress: withdrawer.String(),
+			},
+			resp:      &types.MsgRegisterFeeShareResponse{},
+			shouldErr: false,
+		},
+		{
+			desc: "Invalid withdraw address for factory contract",
+			msg: &types.MsgRegisterFeeShare{
+				ContractAddress:   contractAddress2,
+				DeployerAddress:   sender.String(),
+				WithdrawerAddress: sender.String(),
+			},
+			resp:      &types.MsgRegisterFeeShareResponse{},
+			shouldErr: true,
+		},
+		{
+			desc: "Success register factory contract to itself",
+			msg: &types.MsgRegisterFeeShare{
+				ContractAddress:   contractAddress2,
+				DeployerAddress:   sender.String(),
+				WithdrawerAddress: contractAddress2,
 			},
 			resp:      &types.MsgRegisterFeeShareResponse{},
 			shouldErr: false,

--- a/x/feeshare/spec/00_register.md
+++ b/x/feeshare/spec/00_register.md
@@ -1,0 +1,31 @@
+# Register a contract
+
+`junod tx feeshare register [contract_bech32] [withdraw_bech32] --from [key]`
+
+Registers the withdrawal address for the given contract.
+
+## Parameters
+
+`contract_bech32 (string, required)`: The bech32 address of the contract whose interaction fees will be shared.
+
+`withdraw_bech32 (string, required)`: The bech32 address where the interaction fees will be sent every block.
+
+## Description
+
+This command registers the withdrawal address for the given contract. Any time a user interacts with your contract, the funds will be sent to the withdrawal address. It can be any valid address, such as a DAO, normal account, another contract, or a multi-sig.
+
+## Permissions
+
+This command can only be run by the admin of the contract. If there is no admin, then it can only be run by the contract creator.
+
+## Exceptions
+
+```text
+withdraw_bech32 can not be the community pool (distribution) address. This is a limitation of the way the SDK handles this module account
+```
+
+```text
+For contracts created or administered by a contract factory, the withdrawal address can only be the same as the contract address. This can be registered by anyone, but it's unchangeable. This is helpful for SubDAOs or public goods to save fees in the treasury.
+
+If you create a contract like this, it's best to create an execution method for withdrawing fees to an account. To do this, you'll need to save the withdrawal address in the contract's state before uploading a non-migratable contract.
+```

--- a/x/feeshare/spec/00_update.md
+++ b/x/feeshare/spec/00_update.md
@@ -1,0 +1,11 @@
+# Update a Contract's Withdrawal Address
+
+This can be changed at any time so long as you are still the admin or creator of a contract with the command:
+
+`junod tx feeshare update [contract] [new_withdraw_address]`
+
+## Update Exception
+
+```text
+This can not be done if the contract was created from or is administered by another contract (a contract factory). There is not currently a way for a contract to change its own withdrawal address directly.
+```

--- a/x/feeshare/types/errors.go
+++ b/x/feeshare/types/errors.go
@@ -11,4 +11,5 @@ var (
 	ErrFeeShareNoContractDeployed    = sdkerrrors.Register(ModuleName, 3, "no contract deployed")
 	ErrFeeShareContractNotRegistered = sdkerrrors.Register(ModuleName, 4, "no feeshare registered for contract")
 	ErrFeeSharePayment               = sdkerrrors.Register(ModuleName, 5, "feeshare payment error")
+	ErrFeeShareInvalidWithdrawer     = sdkerrrors.Register(ModuleName, 6, "invalid withdrawer address")
 )


### PR DESCRIPTION
**note** backport to `reece/v13-part1` branch (later to be renamed `release/v13.0.x`

If there is a contract which is made to not be migrated or currently under the rule of a contract (ex: a dao) tthis allows it to register itself without requiring wasmbindings

(also adds vote query for incentivized voting with cosmwasm contracts)

**Idea:**
- DAO creates subDao & is the admin. The SubDAO can be registered and have the funds sent to itself for 50% of fees to the treasury
- Factory creates subContract, but there is no admin. Since Factory is a wasm contract, the contract can be registered to itself to collect fees

**Downside:**
- taxes? but a contract isn't really a business & this is for a small % of contracts
- once registered, this contract can not be changed unless we add wasmbindings. So it can only send funds to itself ever

Example:

```bash
# even with no admin, it can be registered 
junod tx gov submit-proposal instantiate-contract "$CW_CORE" "$FINAL_MSG" --label "SubDAO $(gen_random_string 10)" --title "title" --description 'desc' --run-as $DISTRIBUTION_MODULE --no-admin --amount 0ujuno --deposit 200000ujuno $FLAGS --output json

junod tx feeshare register juno1xr3rq8yvd7qplsw5yx90ftsr2zdhg4e9z60h5duusgxpv72hud3skqksyr juno1xr3rq8yvd7qplsw5yx90ftsr2zdhg4e9z60h5duusgxpv72hud3skqksyr $FLAGS

feeshare:
  contract_address: juno1xr3rq8yvd7qplsw5yx90ftsr2zdhg4e9z60h5duusgxpv72hud3skqksyr
  deployer_address: juno1xr3rq8yvd7qplsw5yx90ftsr2zdhg4e9z60h5duusgxpv72hud3skqksyr
  withdrawer_address: juno1xr3rq8yvd7qplsw5yx90ftsr2zdhg4e9z60h5duusgxpv72hud3skqksyr

# now any interaction with this contract gets 50% of the fees sent to its balance
```