### PR TITLE
[v13] fix(docker): Adds v prefix (ex: v13.0.1)

### DIFF
--- a/.github/workflows/push-docker-images.yml
+++ b/.github/workflows/push-docker-images.yml
@@ -2,11 +2,13 @@
 #
 # On every new `vX.Y.Z` tag the following images are pushed:
 #
+# cosmoscontracts/juno:vX.Y.Z   # is pushed
 # cosmoscontracts/juno:X.Y.Z    # is pushed
 # cosmoscontracts/juno:X.Y      # is updated to X.Y.Z
 # cosmoscontracts/juno:X        # is updated to X.Y.Z
 # cosmoscontracts/juno:latest   # is updated to X.Y.Z
 #
+# cosmoscontracts/juno-e2e:vX.Y.Z    # is pushed
 # cosmoscontracts/juno-e2e:X.Y.Z    # is pushed
 # cosmoscontracts/juno-e2e:X.Y      # is updated to X.Y.Z
 # cosmoscontracts/juno-e2e:X        # is updated to X.Y.Z
@@ -14,9 +16,6 @@
 #
 # On every new `vX.Y.0` tag the following images are pushed:
 #
-# cosmoscontracts/juno-e2e-init-chain:X.Y.0    # is pushed
-# cosmoscontracts/juno-e2e-init-chain:X.Y      # is updated to X.Y.0
-# cosmoscontracts/juno-e2e-init-chain:X        # is updated to X.Y.0
 # All the images above have support for linux/amd64 and linux/arm64.
 #
 # Due to QEMU virtualization used to build multi-platform docker images
@@ -30,6 +29,7 @@ on:
   push:
     tags:
     - 'v[0-9]+.[0-9]+.[0-9]+' # ignore rc
+
 jobs:
   juno-images:
     runs-on: ubuntu-latest
@@ -74,6 +74,8 @@ jobs:
             ghcr.io/cosmoscontracts/juno:${{ env.MAJOR_VERSION }}
             ghcr.io/cosmoscontracts/juno:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}
             ghcr.io/cosmoscontracts/juno:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}.${{ env.PATCH_VERSION }}
+            ghcr.io/cosmoscontracts/juno:v${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}.${{ env.PATCH_VERSION }}
+
   juno-e2e-images:
     runs-on: ubuntu-latest
     steps:
@@ -117,49 +119,4 @@ jobs:
             ghcr.io/cosmoscontracts/juno-e2e:${{ env.MAJOR_VERSION }}
             ghcr.io/cosmoscontracts/juno-e2e:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}
             ghcr.io/cosmoscontracts/juno-e2e:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}.${{ env.PATCH_VERSION }}
-  e2e-init-chain-images:
-    if: startsWith(github.ref, 'refs/tags/v') && endsWith(github.ref, '.0')
-    runs-on: ubuntu-latest
-    steps:
-      - 
-        name: Check out the repo
-        uses: actions/checkout@v3
-      - 
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - 
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2 
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      -
-        name: Parse tag
-        id: tag
-        run: |
-          VERSION=$(echo ${{ github.ref_name }} | sed "s/v//")
-          MAJOR_VERSION=$(echo $VERSION | cut -d '.' -f 1)
-          MINOR_VERSION=$(echo $VERSION | cut -d '.' -f 2)
-          PATCH_VERSION=$(echo $VERSION | cut -d '.' -f 3)
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-          echo "MAJOR_VERSION=$MAJOR_VERSION" >> $GITHUB_ENV
-          echo "MINOR_VERSION=$MINOR_VERSION" >> $GITHUB_ENV
-          echo "PATCH_VERSION=$PATCH_VERSION" >> $GITHUB_ENV
-      - 
-        name: Build and push 
-        id: build_push_e2e_init_image
-        uses: docker/build-push-action@v4
-        with:
-          file: tests/e2e/initialization/init.Dockerfile
-          context: .
-          push: true
-          platforms: linux/amd64,linux/arm64
-          build-args: |
-            E2E_SCRIPT_NAME=chain
-          tags: |
-            ghcr.io/cosmoscontracts/juno-e2e-init-chain:${{ env.MAJOR_VERSION }}
-            ghcr.io/cosmoscontracts/juno-e2e-init-chain:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}
-            ghcr.io/cosmoscontracts/juno-e2e-init-chain:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}.${{ env.PATCH_VERSION }}
+            ghcr.io/cosmoscontracts/juno-e2e:v${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}.${{ env.PATCH_VERSION }}


### PR DESCRIPTION
## CI Failure note
- linting is fixed in another PR
- e2e is being replaced with interchain test in another PR


# PR Fix
Adds the v prefix to the CI - currently v13 is only 13.0.0 in ghcr. This on next tag will make it v13.0.1
Removes old e2e init chain test

I am putting the patch for this in my 597 v14 branch for main

---

Also if someone can delete https://github.com/CosmosContracts/juno/pkgs/container/juno/78312768?tag=reece-initial-v14 from the main juno that would be great :heart: 