### PR TITLE
update to wasmd v0.32

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/CosmWasm/token-factory v0.0.0-00010101000000-000000000000
-	github.com/CosmWasm/wasmd v0.31.0
+	github.com/CosmWasm/wasmd v0.31.1-0.20230322155833-d48bb69b391e
 	github.com/cometbft/cometbft-db v0.7.0
 	github.com/cosmos/cosmos-sdk v0.45.15
 	github.com/cosmos/gaia/v9 v9.0.1
@@ -159,18 +159,24 @@ require (
 replace (
 	// cosmos keyring
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.2.0
+
 	// token factory:
 	github.com/CosmWasm/token-factory => github.com/CosmosContracts/token-factory v1.1.1-0.20230322161639-a1f5cfad5f4a
+
 	// TODO: Simapp dependency, review removing when updating to SDK with backported update https://github.com/cosmos/cosmos-sdk/issues/13423
 	github.com/btcsuite/btcd => github.com/btcsuite/btcd v0.22.2 // indirect
+
 	// dgrijalva/jwt-go is deprecated and doesn't receive security updates.
 	// TODO: remove it: https://github.com/cosmos/cosmos-sdk/issues/13134
 	github.com/dgrijalva/jwt-go => github.com/golang-jwt/jwt/v4 v4.4.2
+
 	// Fix upstream GHSA-h395-qcrw-5vmq vulnerability.
 	// TODO Remove it: https://github.com/cosmos/cosmos-sdk/issues/10409
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.8.1
+
 	// use cosmos-flavored protocol buffers
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
+
 	// cometbft
 	github.com/tendermint/tendermint => github.com/cometbft/cometbft v0.34.27
 	// use grpc version that's compatible with cosmos-flavored protocol buffers

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/CloudyKit/fastprinter v0.0.0-20170127035650-74b38d55f37a/go.mod h1:EF
 github.com/CloudyKit/fastprinter v0.0.0-20200109182630-33d98a066a53/go.mod h1:+3IMCy2vIlbG1XG/0ggNQv0SvxCAIpPM5b1nCz56Xno=
 github.com/CloudyKit/jet v2.1.3-0.20180809161101-62edd43e4f88+incompatible/go.mod h1:HPYO+50pSWkPoj9Q/eq0aRGByCL6ScRlUmiEX5Zgm+w=
 github.com/CloudyKit/jet/v3 v3.0.0/go.mod h1:HKQPgSJmdK8hdoAbKUUWajkHyHo4RaU5rMdUywE7VMo=
-github.com/CosmWasm/wasmd v0.31.0 h1:xACf6A/SkCeGWQWrKGsR4X9PQb5G4XYuNfnrl+HQ1mE=
-github.com/CosmWasm/wasmd v0.31.0/go.mod h1:VcyDGk/ISVlMUeW+1GGL0zdHWBS2FPwLEV2qZ86l7l8=
+github.com/CosmWasm/wasmd v0.31.1-0.20230322155833-d48bb69b391e h1:6xYOYp0mkTICuO8BHXG0XIzWj4N/z/CA96DluOu1Ht8=
+github.com/CosmWasm/wasmd v0.31.1-0.20230322155833-d48bb69b391e/go.mod h1:jzHor6sCH+jgbBSStOZRBe0B0aN0nrZbg5+lpuUk4Mo=
 github.com/CosmWasm/wasmvm v1.2.1 h1:si0tRsRDdUShV0k51Wn6zRKlmj3/WWP9Yr4cLmDTf+8=
 github.com/CosmWasm/wasmvm v1.2.1/go.mod h1:vW/E3h8j9xBQs9bCoijDuawKo9kCtxOaS8N8J7KFtkc=
 github.com/CosmosContracts/token-factory v1.1.1-0.20230322161639-a1f5cfad5f4a h1:o4vOyEqNIfw6GdGH83EZFDJjqlQ3WIHhIWmOBh7BqB4=


### PR DESCRIPTION
This PR updates Juno to wasmd v0.32.0

(they've yet to tag but are currently just doing release notes:

* https://github.com/CosmWasm/wasmd/pull/1285
)


