### PR TITLE
short block times

### DIFF
--- a/cmd/junod/cmd/root.go
+++ b/cmd/junod/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
@@ -87,6 +88,9 @@ func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 			if err := client.SetCmdClientContextHandler(initClientCtx, cmd); err != nil {
 				return err
 			}
+
+			serverCtx := server.GetServerContextFromCmd(cmd)
+			serverCtx.Config.Consensus.TimeoutCommit = 2 * time.Second
 
 			return server.InterceptConfigsPreRunHandler(cmd, "", nil)
 		},


### PR DESCRIPTION
This PR will shorten Juno's block times. 

With this PR we should get block times of about three seconds and validators should not be able to adjust the commit timeout.
