### PR TITLE
[v15] Forced Faster Block Times (3 seconds)

### DIFF
--- a/cmd/junod/cmd/root.go
+++ b/cmd/junod/cmd/root.go
@@ -41,10 +41,6 @@ import (
 	"github.com/CosmosContracts/juno/v15/app/params"
 )
 
-const (
-	EnvPrefix = "JUNO"
-)
-
 // NewRootCmd creates a new root command for junod. It is called once in the
 // main function.
 func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
@@ -66,7 +62,7 @@ func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 		WithAccountRetriever(authtypes.AccountRetriever{}).
 		WithBroadcastMode(flags.BroadcastBlock).
 		WithHomeDir(app.DefaultNodeHome).
-		WithViper(EnvPrefix)
+		WithViper("")
 
 	// Allows you to add extra params to your client.toml
 	// gas, gas-price, gas-adjustment, fees, note, etc.

--- a/cmd/junod/cmd/server_configs.go
+++ b/cmd/junod/cmd/server_configs.go
@@ -45,8 +45,8 @@ func InterceptConfigsPreRunHandler(cmd *cobra.Command, customAppConfigTemplate s
 	basename := path.Base(executableName)
 
 	// Configure the viper instance
-	serverCtx.Viper.BindPFlags(cmd.Flags())
-	serverCtx.Viper.BindPFlags(cmd.PersistentFlags())
+	serverCtx.Viper.BindPFlags(cmd.Flags())           // nolint: errcheck
+	serverCtx.Viper.BindPFlags(cmd.PersistentFlags()) // nolint: errcheck
 	serverCtx.Viper.SetEnvPrefix(basename)
 	serverCtx.Viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_"))
 	serverCtx.Viper.AutomaticEnv()
@@ -165,7 +165,7 @@ func interceptConfigs(rootViper *viper.Viper, customAppTemplate string, customCo
 
 func bindFlags(basename string, cmd *cobra.Command, v *viper.Viper) (err error) {
 	defer func() {
-		recover()
+		recover() // nolint: errcheck
 	}()
 
 	cmd.Flags().VisitAll(func(f *pflag.Flag) {

--- a/cmd/junod/cmd/server_configs.go
+++ b/cmd/junod/cmd/server_configs.go
@@ -1,0 +1,195 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+	tmcfg "github.com/tendermint/tendermint/config"
+
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/server/config"
+
+	server "github.com/cosmos/cosmos-sdk/server"
+)
+
+// InterceptConfigsPreRunHandler performs a pre-run function for the root daemon
+// application command. It will create a Viper literal and a default server
+// Context. The server Tendermint configuration will either be read and parsed
+// or created and saved to disk, where the server Context is updated to reflect
+// the Tendermint configuration. It takes custom app config template and config
+// settings to create a custom Tendermint configuration. If the custom template
+// is empty, it uses default-template provided by the server. The Viper literal
+// is used to read and parse the application configuration. Command handlers can
+// fetch the server Context to get the Tendermint configuration or to get access
+// to Viper.
+func InterceptConfigsPreRunHandler(cmd *cobra.Command, customAppConfigTemplate string, customAppConfig interface{}, blockTimeout time.Duration) error {
+	serverCtx := server.NewDefaultContext()
+
+	// Get the executable name and configure the viper instance so that environmental
+	// variables are checked based off that name. The underscore character is used
+	// as a separator
+	executableName, err := os.Executable()
+	if err != nil {
+		return err
+	}
+
+	basename := path.Base(executableName)
+
+	// Configure the viper instance
+	serverCtx.Viper.BindPFlags(cmd.Flags())
+	serverCtx.Viper.BindPFlags(cmd.PersistentFlags())
+	serverCtx.Viper.SetEnvPrefix(basename)
+	serverCtx.Viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_"))
+	serverCtx.Viper.AutomaticEnv()
+
+	// intercept configuration files, using both Viper instances separately
+	config, err := interceptConfigs(serverCtx.Viper, customAppConfigTemplate, customAppConfig)
+	if err != nil {
+		return err
+	}
+
+	// !IMPORTANT: This is the only modified part of the original functions from the SDK
+	config.Consensus.TimeoutCommit = blockTimeout
+
+	// return value is a tendermint configuration object
+	serverCtx.Config = config
+	if err = bindFlags(basename, cmd, serverCtx.Viper); err != nil {
+		return err
+	}
+
+	var logWriter io.Writer
+	if strings.ToLower(serverCtx.Viper.GetString(flags.FlagLogFormat)) == tmcfg.LogFormatPlain {
+		logWriter = zerolog.ConsoleWriter{Out: os.Stderr}
+	} else {
+		logWriter = os.Stderr
+	}
+
+	logLvlStr := serverCtx.Viper.GetString(flags.FlagLogLevel)
+	logLvl, err := zerolog.ParseLevel(logLvlStr)
+	if err != nil {
+		return fmt.Errorf("failed to parse log level (%s): %w", logLvlStr, err)
+	}
+
+	serverCtx.Logger = server.ZeroLogWrapper{Logger: zerolog.New(logWriter).Level(logLvl).With().Timestamp().Logger()}
+
+	return server.SetCmdServerContext(cmd, serverCtx)
+}
+
+// interceptConfigs parses and updates a Tendermint configuration file or
+// creates a new one and saves it. It also parses and saves the application
+// configuration file. The Tendermint configuration file is parsed given a root
+// Viper object, whereas the application is parsed with the private package-aware
+// viperCfg object.
+func interceptConfigs(rootViper *viper.Viper, customAppTemplate string, customConfig interface{}) (*tmcfg.Config, error) {
+	rootDir := rootViper.GetString(flags.FlagHome)
+	configPath := filepath.Join(rootDir, "config")
+	tmCfgFile := filepath.Join(configPath, "config.toml")
+
+	conf := tmcfg.DefaultConfig()
+
+	switch _, err := os.Stat(tmCfgFile); {
+	case os.IsNotExist(err):
+		tmcfg.EnsureRoot(rootDir)
+
+		if err = conf.ValidateBasic(); err != nil {
+			return nil, fmt.Errorf("error in config file: %v", err)
+		}
+
+		conf.RPC.PprofListenAddress = "localhost:6060"
+		conf.P2P.RecvRate = 5120000
+		conf.P2P.SendRate = 5120000
+		conf.Consensus.TimeoutCommit = 5 * time.Second
+		tmcfg.WriteConfigFile(tmCfgFile, conf)
+
+	case err != nil:
+		return nil, err
+
+	default:
+		rootViper.SetConfigType("toml")
+		rootViper.SetConfigName("config")
+		rootViper.AddConfigPath(configPath)
+
+		if err := rootViper.ReadInConfig(); err != nil {
+			return nil, fmt.Errorf("failed to read in %s: %w", tmCfgFile, err)
+		}
+	}
+
+	// Read into the configuration whatever data the viper instance has for it.
+	// This may come from the configuration file above but also any of the other
+	// sources viper uses.
+	if err := rootViper.Unmarshal(conf); err != nil {
+		return nil, err
+	}
+
+	conf.SetRoot(rootDir)
+
+	appCfgFilePath := filepath.Join(configPath, "app.toml")
+	if _, err := os.Stat(appCfgFilePath); os.IsNotExist(err) {
+		if customAppTemplate != "" {
+			config.SetConfigTemplate(customAppTemplate)
+
+			if err = rootViper.Unmarshal(&customConfig); err != nil {
+				return nil, fmt.Errorf("failed to parse %s: %w", appCfgFilePath, err)
+			}
+
+			config.WriteConfigFile(appCfgFilePath, customConfig)
+		} else {
+			appConf, err := config.ParseConfig(rootViper)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse %s: %w", appCfgFilePath, err)
+			}
+
+			config.WriteConfigFile(appCfgFilePath, appConf)
+		}
+	}
+
+	rootViper.SetConfigType("toml")
+	rootViper.SetConfigName("app")
+	rootViper.AddConfigPath(configPath)
+
+	if err := rootViper.MergeInConfig(); err != nil {
+		return nil, fmt.Errorf("failed to merge configuration: %w", err)
+	}
+
+	return conf, nil
+}
+
+func bindFlags(basename string, cmd *cobra.Command, v *viper.Viper) (err error) {
+	defer func() {
+		recover()
+	}()
+
+	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+		// Environment variables can't have dashes in them, so bind them to their equivalent
+		// keys with underscores, e.g. --favorite-color to STING_FAVORITE_COLOR
+		err = v.BindEnv(f.Name, fmt.Sprintf("%s_%s", basename, strings.ToUpper(strings.ReplaceAll(f.Name, "-", "_"))))
+		if err != nil {
+			panic(err)
+		}
+
+		err = v.BindPFlag(f.Name, f)
+		if err != nil {
+			panic(err)
+		}
+
+		// Apply the viper config value to the flag when the flag is not set and viper has a value
+		if !f.Changed && v.IsSet(f.Name) {
+			val := v.Get(f.Name)
+			err = cmd.Flags().Set(f.Name, fmt.Sprintf("%v", val))
+			if err != nil {
+				panic(err)
+			}
+		}
+	})
+
+	return
+}

--- a/go.mod
+++ b/go.mod
@@ -129,11 +129,11 @@ require (
 	github.com/regen-network/cosmos-proto v0.3.1 // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	github.com/rs/cors v1.8.2 // indirect
-	github.com/rs/zerolog v1.27.0 // indirect
+	github.com/rs/zerolog v1.27.0
 	github.com/sasha-s/go-deadlock v0.3.1 // indirect
 	github.com/spf13/afero v1.9.3 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.15.0
 	github.com/subosito/gotenv v1.4.2 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7


### PR DESCRIPTION
**Merges into v15-initial branch**

## Changes
- Pulls out the `server.InterceptConfigsPreRunHandler` function into its own file
- Adds `blockTimeout` and force set it with `config.Consensus.TimeoutCommit` any time the junod command is run

### Bonus Addition
- Adds the wasmconfig to increase gas queries to the config for all

## Check
```bash
CHAIN_ID="local-1" HOME_DIR="~/.juno1" TIMEOUT_COMMIT="100ms" CLEAN=true sh scripts/test_node.sh
```

Even with 100ms set as your config.toml, it still uses the set 3 seconds.

---

## Reason
SDK v46/47 fix this by allowing direct modification of the tendermint config. This is why it has to be "soft forked" into a single file. 

Other chains which have implemented this feature already hard forked the SDK. Would rather not