### PR TITLE
(chore): bump mev-tendermint to v0.34.27-mev.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -172,7 +172,7 @@ replace (
 	// use cosmos-flavored protocol buffers
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	// cometbft
-	github.com/tendermint/tendermint => github.com/skip-mev/mev-cometbft v0.34.27-mev.17
+	github.com/tendermint/tendermint => github.com/skip-mev/mev-cometbft v0.34.27-mev.18
 	// use grpc version that's compatible with cosmos-flavored protocol buffers
 	google.golang.org/grpc => google.golang.org/grpc v1.33.2
 )

--- a/go.sum
+++ b/go.sum
@@ -931,8 +931,8 @@ github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6Mwd
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
-github.com/skip-mev/mev-cometbft v0.34.27-mev.17 h1:Sti5vpx6jvUzmLcsi22Xv9hf8eByXz6fKrKS3tACckw=
-github.com/skip-mev/mev-cometbft v0.34.27-mev.17/go.mod h1:BcCbhKv7ieM0KEddnYXvQZR+pZykTKReJJYf7YC7qhw=
+github.com/skip-mev/mev-cometbft v0.34.27-mev.18 h1:xoZRzzW4u4Rr4jjXUz7y05AoDZu8W5dGvgeg7jxrt0U=
+github.com/skip-mev/mev-cometbft v0.34.27-mev.18/go.mod h1:BcCbhKv7ieM0KEddnYXvQZR+pZykTKReJJYf7YC7qhw=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=


### PR DESCRIPTION
This release provides a QoL improvement for validators by suppressing warning messages that arise when a validator has a partially configured mev-tendermint

https://github.com/skip-mev/mev-cometbft/releases/tag/v0.34.27-mev.18