### PR TITLE
Add allowed Stargate query: distribution `DelegationRewards`

### DIFF
--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -382,6 +382,9 @@ func NewAppKeepers(
 		// governance
 		"/cosmos.gov.v1beta1.Query/Vote": &govtypes.QueryVoteResponse{},
 
+		// distribution
+		"/cosmos.distribution.v1beta1.Query/DelegationRewards": &distrtypes.QueryDelegationRewardsResponse{},
+
 		// staking
 		"/cosmos.staking.v1beta1.Query/Delegation":          &stakingtypes.QueryDelegationResponse{},
 		"/cosmos.staking.v1beta1.Query/Redelegations":       &stakingtypes.QueryRedelegationsResponse{},


### PR DESCRIPTION
I believe it will be beneficial to Juno to add another allowed Stargate query.

See this query that we're talking about:
https://github.com/cosmos/cosmos-sdk/blob/v0.45.15/proto/cosmos/distribution/v1beta1/query.proto#L37-L41

With this addition, we'll see more programmatic claiming and staking of native tokens. Actually, this Twitter thread details how we can actually just delegate instead of the two-step claim-and-delegate flow we're accustomed to:
https://twitter.com/larry0x/status/1621959355221348352

I believe exposing this query doesn't introduce security concerns, and will help delegation UX if we do.

## An example

As an example, check this out… Here's my account with native balance and some tokens that need to be claimed.

![image](https://user-images.githubusercontent.com/1042667/235366784-718163ca-4b3a-4a1f-a84d-3a160381b04a.png)

Then (without claiming) I sent a `delegate` command for 31 JUNO, which can only succeed if both values are combined.

`junod tx staking delegate junovaloper1gp957czryfgyvxwn3tfnyy2f0t9g2p4pvzc6k3 31000000ujuno --from mikereg -y | jq`

https://www.mintscan.io/juno/txs/454F89DDB856E5A7C68E91D7D72884C243012F1FB46B440ECEFDE234342E2EBF

I was expecting that we'd be able to ascertain how many tokens are available to claim using Stargate queries under `cosmos.staking.…`, which are on the safe Stargate list, but the only query I'm seeing that can get this is the one I've added in this PR from `cosmos.distribution.…`.

If we add this Stargate query, then CosmWasm contracts can leverage authz, and efficiently redelegate in a single transaction instead of claiming and delegating, which isn't necessary. I have more ideas but will 🤐 and keep it at that.

## ❤️ 

Shoutout to Reece, who has the sole search result providing a great template for this:

<img width="1428" alt="Screen Shot 2023-04-29 at 8 09 24 PM" src="https://user-images.githubusercontent.com/1042667/235366667-45026430-2e7b-4601-8d93-dd539f9b8ae7.png">

