### PR TITLE
[v15] FeeShare register of governance admin contracts

### DIFF
--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -437,6 +437,7 @@ func NewAppKeepers(
 		appKeepers.GetSubspace(feesharetypes.ModuleName),
 		appKeepers.BankKeeper,
 		appKeepers.WasmKeeper,
+		appKeepers.AccountKeeper,
 		authtypes.FeeCollectorName,
 	)
 

--- a/x/feeshare/keeper/keeper.go
+++ b/x/feeshare/keeper/keeper.go
@@ -21,8 +21,9 @@ type Keeper struct {
 	cdc        codec.BinaryCodec
 	paramstore paramtypes.Subspace
 
-	bankKeeper revtypes.BankKeeper
-	wasmKeeper wasmkeeper.Keeper
+	bankKeeper    revtypes.BankKeeper
+	wasmKeeper    wasmkeeper.Keeper
+	accountKeeper revtypes.AccountKeeper
 
 	feeCollectorName string
 }
@@ -34,6 +35,7 @@ func NewKeeper(
 	ps paramtypes.Subspace,
 	bk revtypes.BankKeeper,
 	wk wasmkeeper.Keeper,
+	ak revtypes.AccountKeeper,
 	feeCollector string,
 ) Keeper {
 	// set KeyTable if it has not already been set
@@ -47,6 +49,7 @@ func NewKeeper(
 		paramstore:       ps,
 		bankKeeper:       bk,
 		wasmKeeper:       wk,
+		accountKeeper:    ak,
 		feeCollectorName: feeCollector,
 	}
 }


### PR DESCRIPTION
In its current state, a gov admin'ed contract/DAO can not be self registered.

With this, if the admin of said contract is the gov module (ex: Core-1 subdao) it can now be registered to itself for feeshare income.

This is a very minor logic change
```go
govAddress := k.accountKeeper.GetModuleAddress(govtypes.ModuleName).String()
contractInfo.Admin == govAddress {
     return true; // allow self register as a 'factory' contract
}
```

---

## Testing
Tested manually, will add ictest after we get in the x/tokenfactory PR with IC changes

Trying to withdraw to another addr
![image](https://user-images.githubusercontent.com/31943163/236586789-815c4aa8-55d4-4689-b076-e0209bce3cc9.png)

Correctly withdrawing to itself 
![image](https://user-images.githubusercontent.com/31943163/236586838-1a042f5c-8e42-4786-8ecd-29a98cb9b3f2.png)