### PR TITLE
Move Wolf's Vesting account -> Core-1 subDAO

### DIFF
--- a/app/upgrades/v16/upgrades.go
+++ b/app/upgrades/v16/upgrades.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
+
 	// SDK v47 modules
 	// minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
@@ -30,6 +31,7 @@ import (
 
 	"github.com/CosmosContracts/juno/v16/app/keepers"
 	"github.com/CosmosContracts/juno/v16/app/upgrades"
+
 	// Juno modules
 	feesharetypes "github.com/CosmosContracts/juno/v16/x/feeshare/types"
 	globalfeetypes "github.com/CosmosContracts/juno/v16/x/globalfee/types"
@@ -38,8 +40,8 @@ import (
 )
 
 const (
-	// TODO: This is my testing local account, not wolfs. need list from Core-1.
-	WolfsMainnetVestingAccount = "juno1xz599egrd3dhq5vx63mkwja38q5q3th8h3ukjj"
+	// Wolf's periodic vesting account (confirmed with him)
+	WolfsMainnetVestingAccount = "juno1a8u47ggy964tv9trjxfjcldutau5ls705djqyu"
 	// Core-1 Mainnet Address
 	Core1SubDAOAddress = "juno1j6glql3xmrcnga0gytecsucq3kd88jexxamxg3yn2xnqhunyvflqr7lxx3"
 )

--- a/app/upgrades/v16/upgrades.go
+++ b/app/upgrades/v16/upgrades.go
@@ -42,8 +42,8 @@ import (
 const (
 	// TODO: This is my testing local account, not wolfs. need list from Core-1.
 	WolfsMainnetVestingAccount = "juno1xz599egrd3dhq5vx63mkwja38q5q3th8h3ukjj"
-	// TODO: Replace with the DAO addr
-	Core1SubDAOAddress = "juno1reece3m8g4m3d0qrpj93rnnseudnpzhr0kewyl"
+	// Core-1 Mainnet Address
+	Core1SubDAOAddress = "juno1j6glql3xmrcnga0gytecsucq3kd88jexxamxg3yn2xnqhunyvflqr7lxx3"
 )
 
 func CreateV16UpgradeHandler(
@@ -153,6 +153,8 @@ func CreateV16UpgradeHandler(
 			return nil, err
 		}
 
+		// TODO: Mainnet only
+		// if ctx.ChainID() == "juno-1" {}
 		if err := removeWolfCore1VestingAccountAndReturnToCore1(ctx, keepers, nativeDenom); err != nil {
 			return nil, err
 		}
@@ -162,18 +164,12 @@ func CreateV16UpgradeHandler(
 }
 
 func removeWolfCore1VestingAccountAndReturnToCore1(ctx sdk.Context, keepers *keepers.AppKeepers, bondDenom string) error {
-
 	addr := sdk.MustAccAddressFromBech32(WolfsMainnetVestingAccount)
 
-	// TODO: chain id check for juno-1 only.
-	upgrades.MoveVestingCoinFromVestingAccount(ctx,
+	return upgrades.MoveVestingCoinFromVestingAccount(ctx,
 		addr,
 		keepers,
 		Core1SubDAOAddress,
 		bondDenom,
 	)
-
-	// return error
-	// return fmt.Errorf("completed remove wolf logic,")
-	return nil
 }

--- a/app/upgrades/v16/upgrades.go
+++ b/app/upgrades/v16/upgrades.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
+
 	// SDK v47 modules
 	// minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
@@ -30,6 +31,7 @@ import (
 
 	"github.com/CosmosContracts/juno/v16/app/keepers"
 	"github.com/CosmosContracts/juno/v16/app/upgrades"
+
 	// Juno modules
 	feesharetypes "github.com/CosmosContracts/juno/v16/x/feeshare/types"
 	globalfeetypes "github.com/CosmosContracts/juno/v16/x/globalfee/types"

--- a/app/upgrades/v16/upgrades.go
+++ b/app/upgrades/v16/upgrades.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
-
 	// SDK v47 modules
 	// minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
@@ -31,7 +30,6 @@ import (
 
 	"github.com/CosmosContracts/juno/v16/app/keepers"
 	"github.com/CosmosContracts/juno/v16/app/upgrades"
-
 	// Juno modules
 	feesharetypes "github.com/CosmosContracts/juno/v16/x/feeshare/types"
 	globalfeetypes "github.com/CosmosContracts/juno/v16/x/globalfee/types"
@@ -153,10 +151,11 @@ func CreateV16UpgradeHandler(
 			return nil, err
 		}
 
-		// TODO: Mainnet only
-		// if ctx.ChainID() == "juno-1" {}
-		if err := removeWolfCore1VestingAccountAndReturnToCore1(ctx, keepers, nativeDenom); err != nil {
-			return nil, err
+		// Migrate Core-1 vesting account remaining funds -> Core-1
+		if ctx.ChainID() == "juno-1" {
+			if err := removeWolfCore1VestingAccountAndReturnToCore1(ctx, keepers, nativeDenom); err != nil {
+				return nil, err
+			}
 		}
 
 		return versionMap, err

--- a/app/upgrades/v16/upgrades.go
+++ b/app/upgrades/v16/upgrades.go
@@ -165,12 +165,10 @@ func CreateV16UpgradeHandler(
 }
 
 func removeWolfCore1VestingAccountAndReturnToCore1(ctx sdk.Context, keepers *keepers.AppKeepers, bondDenom string) error {
-	addr := sdk.MustAccAddressFromBech32(WolfsMainnetVestingAccount)
-
 	return upgrades.MoveVestingCoinFromVestingAccount(ctx,
-		addr,
 		keepers,
-		Core1SubDAOAddress,
 		bondDenom,
+		sdk.MustAccAddressFromBech32(WolfsMainnetVestingAccount),
+		sdk.MustAccAddressFromBech32(Core1SubDAOAddress),
 	)
 }

--- a/app/upgrades/v16/upgrades.go
+++ b/app/upgrades/v16/upgrades.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
+
 	// SDK v47 modules
 	// minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
@@ -30,11 +31,19 @@ import (
 
 	"github.com/CosmosContracts/juno/v16/app/keepers"
 	"github.com/CosmosContracts/juno/v16/app/upgrades"
+
 	// Juno modules
 	feesharetypes "github.com/CosmosContracts/juno/v16/x/feeshare/types"
 	globalfeetypes "github.com/CosmosContracts/juno/v16/x/globalfee/types"
 	minttypes "github.com/CosmosContracts/juno/v16/x/mint/types"
 	tokenfactorytypes "github.com/CosmosContracts/juno/v16/x/tokenfactory/types"
+)
+
+const (
+	// TODO: This is my testing local account, not wolfs. need list from Core-1.
+	WolfsMainnetVestingAccount = "juno1xz599egrd3dhq5vx63mkwja38q5q3th8h3ukjj"
+	// TODO: Replace with the DAO addr
+	Core1SubDAOAddress = "juno1reece3m8g4m3d0qrpj93rnnseudnpzhr0kewyl"
 )
 
 func CreateV16UpgradeHandler(
@@ -144,6 +153,35 @@ func CreateV16UpgradeHandler(
 			return nil, err
 		}
 
+		if err := removeWolfCore1VestingAccountAndReturnToCore1(ctx, keepers, nativeDenom); err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf("not implemented")
+
 		return versionMap, err
 	}
+}
+
+func removeWolfCore1VestingAccountAndReturnToCore1(ctx sdk.Context, keepers *keepers.AppKeepers, bondDenom string) error {
+
+	addr := sdk.MustAccAddressFromBech32(WolfsMainnetVestingAccount)
+
+	// TODO: chain id check for juno-1 only.
+	coin, _ := upgrades.MoveVestingCoinFromVestingAccount(ctx,
+		addr,
+		keepers,
+		Core1SubDAOAddress,
+		bondDenom,
+	)
+
+	// return error
+	return fmt.Errorf("vesting account %s has %v coins", WolfsMainnetVestingAccount, coin)
+
+	// fmt.Printf("Vesting account %s has %s\n", WolfsMainnetVestingAccount, coin.String())
+
+	// if coin.IsZero() {
+	// 	return fmt.Errorf("vesting account %s has no coins", WolfsMainnetVestingAccount)
+	// }
+
+	// return nil
 }

--- a/app/upgrades/v16/upgrades.go
+++ b/app/upgrades/v16/upgrades.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
-
 	// SDK v47 modules
 	// minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
@@ -31,7 +30,6 @@ import (
 
 	"github.com/CosmosContracts/juno/v16/app/keepers"
 	"github.com/CosmosContracts/juno/v16/app/upgrades"
-
 	// Juno modules
 	feesharetypes "github.com/CosmosContracts/juno/v16/x/feeshare/types"
 	globalfeetypes "github.com/CosmosContracts/juno/v16/x/globalfee/types"

--- a/app/upgrades/v16/upgrades.go
+++ b/app/upgrades/v16/upgrades.go
@@ -156,7 +156,6 @@ func CreateV16UpgradeHandler(
 		if err := removeWolfCore1VestingAccountAndReturnToCore1(ctx, keepers, nativeDenom); err != nil {
 			return nil, err
 		}
-		return nil, fmt.Errorf("not implemented")
 
 		return versionMap, err
 	}
@@ -167,7 +166,7 @@ func removeWolfCore1VestingAccountAndReturnToCore1(ctx sdk.Context, keepers *kee
 	addr := sdk.MustAccAddressFromBech32(WolfsMainnetVestingAccount)
 
 	// TODO: chain id check for juno-1 only.
-	coin, _ := upgrades.MoveVestingCoinFromVestingAccount(ctx,
+	upgrades.MoveVestingCoinFromVestingAccount(ctx,
 		addr,
 		keepers,
 		Core1SubDAOAddress,
@@ -175,13 +174,6 @@ func removeWolfCore1VestingAccountAndReturnToCore1(ctx sdk.Context, keepers *kee
 	)
 
 	// return error
-	return fmt.Errorf("vesting account %s has %v coins", WolfsMainnetVestingAccount, coin)
-
-	// fmt.Printf("Vesting account %s has %s\n", WolfsMainnetVestingAccount, coin.String())
-
-	// if coin.IsZero() {
-	// 	return fmt.Errorf("vesting account %s has no coins", WolfsMainnetVestingAccount)
-	// }
-
-	// return nil
+	// return fmt.Errorf("completed remove wolf logic,")
+	return nil
 }

--- a/app/upgrades/vesting.go
+++ b/app/upgrades/vesting.go
@@ -8,9 +8,9 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	authvestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
-	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 )
 
+// TODO: Redelegations check as well.
 func undelegate(ctx sdk.Context, now time.Time, keepers *keepers.AppKeepers, accAddr sdk.AccAddress, vacc *authvestingtypes.ContinuousVestingAccount) error {
 	// Unbond all delegations from the account
 	delegations := keepers.StakingKeeper.GetAllDelegatorDelegations(ctx, accAddr)
@@ -63,17 +63,19 @@ func undelegate(ctx sdk.Context, now time.Time, keepers *keepers.AppKeepers, acc
 
 func checkLockedCoins(vacc *authvestingtypes.ContinuousVestingAccount, now time.Time) sdk.Coins {
 	locked := vacc.LockedCoins(now)
-	locakedVesting := vacc.LockedCoinsFromVesting(vacc.GetVestingCoins(now))
+	lockedFromVesting := vacc.LockedCoinsFromVesting(vacc.GetVestingCoins(now))
 	fmt.Printf("locked: %v\n", locked)
-	fmt.Printf("locakedVesting: %v\n", locakedVesting)
+	fmt.Printf("lockedVesting: %v\n", lockedFromVesting)
 	return locked
 }
 
-// Undelegates all tokens, and send it back to the core1 subdao address for the vesting contract to instantiate
+// Stops a vesting account and returns all tokens back to the Core-1 subdao.
 func MoveVestingCoinFromVestingAccount(ctx sdk.Context, accAddr sdk.AccAddress, keepers *keepers.AppKeepers, core1SubDaoAddress string, bondDenom string) (sdk.Coin, error) {
-	var err error
+	// var err error
 
 	now := ctx.BlockHeader().Time
+
+	core1AccAddr := sdk.MustAccAddressFromBech32(core1SubDaoAddress)
 
 	stdAcc := keepers.AccountKeeper.GetAccount(ctx, accAddr)
 	vacc, ok := stdAcc.(*authvestingtypes.ContinuousVestingAccount)
@@ -85,161 +87,37 @@ func MoveVestingCoinFromVestingAccount(ctx sdk.Context, accAddr sdk.AccAddress, 
 	l := checkLockedCoins(vacc, now)
 	fmt.Printf("l: %v\n", l)
 
-	// set end time to now to unlock.
-	vacc.EndTime = now.Unix() - 1_000_000
-	vacc.BaseVestingAccount.EndTime = now.Unix() - 1_000_000
-	// vacc.DelegatedFree = sdk.NewCoins()
-	// vacc.DelegatedVesting = sdk.NewCoins()
-	// vacc.OriginalVesting = sdk.NewCoins()
-	// vacc.BaseVestingAccount.DelegatedFree = sdk.NewCoins()
-	// vacc.BaseVestingAccount.DelegatedVesting = sdk.NewCoins()
-	// vacc.BaseVestingAccount.OriginalVesting = sdk.NewCoins()
+	// Finish vesting period now.
+	vacc.EndTime = 1
+	vacc.BaseVestingAccount.EndTime = 1
+	keepers.AccountKeeper.SetAccount(ctx, vacc)
 
-	// Nothing shown here.
-	checkLockedCoins(vacc, now)
-
-	// undelegate all.
+	// Instant unbond all tokens, goes into balance.
 	if err := undelegate(ctx, now, keepers, accAddr, vacc); err != nil {
 		return sdk.Coin{}, err
 	}
 
-	bal := keepers.BankKeeper.GetBalance(ctx, accAddr, bondDenom)
-	fmt.Printf("Balance: %s\n", bal)
-	if err := keepers.BankKeeper.SendCoinsFromAccountToModule(ctx, accAddr, distrtypes.ModuleName, sdk.NewCoins(bal)); err != nil {
-		return sdk.Coin{}, err
+	// Get balance
+	accbal := keepers.BankKeeper.GetBalance(ctx, accAddr, bondDenom)
+	fmt.Printf("bal: %v\n", accbal)
+
+	// Send all tokens from balance to the core-1 subdao address
+	if e := keepers.BankKeeper.SendCoins(ctx, accAddr, core1AccAddr, sdk.NewCoins(accbal)); e != nil {
+		return sdk.Coin{}, fmt.Errorf("error sending coins: %v", e)
 	}
 
-	// get distrtypes.ModuleName balance
-	distrtypesModuleBalance := keepers.BankKeeper.GetBalance(ctx, sdk.AccAddress(distrtypes.ModuleName), bondDenom)
-	fmt.Printf("distrtypesModuleBalance: %v\n", distrtypesModuleBalance)
+	// get bal of core1SubDaoAddress
+	core1BalC := keepers.BankKeeper.GetBalance(ctx, sdk.MustAccAddressFromBech32(core1SubDaoAddress), bondDenom)
+	fmt.Printf("core1Bal: %v\n", core1BalC)
 
-	// update vacc to be entirely spendable
-	// vacc.DelegatedFree = sdk.NewCoins(bal)
-	// vacc.BaseVestingAccount.DelegatedFree = sdk.NewCoins(bal)
+	// get balance of accAddr
+	accbal = keepers.BankKeeper.GetBalance(ctx, accAddr, bondDenom)
+	fmt.Printf("bal: %v\n", accbal)
 
-	fmt.Printf("MoveVestingCoinFromVestingAccount: %s\n", vacc)
+	// TODO: Delete said account? (no reason to have it or the abse account anymore yea? any issues of doing this?)
+	// if so, do we have to remove all the subAccounts first of the vacc/
+	keepers.AccountKeeper.RemoveAccount(ctx, vacc)
 
-	// send funds since they are unlocked.
-	// spendable balance here is nil.
-	fmt.Print("sending\n", keepers.BankKeeper.GetBalance(ctx, accAddr, bondDenom))
-	if err := keepers.BankKeeper.SendCoins(ctx, accAddr, sdk.AccAddress(core1SubDaoAddress), sdk.NewCoins(bal)); err != nil {
-		return sdk.Coin{}, err
-	}
-
-	fmt.Printf("MoveVestingCoinFromVestingAccount: %s\n", vacc)
-
-	core1Bal := keepers.BankKeeper.GetBalance(ctx, sdk.AccAddress(core1SubDaoAddress), bondDenom)
-	fmt.Printf("core1Bal: %v\n", core1Bal)
-
-	return sdk.Coin{}, fmt.Errorf("not implemented")
-
-	// undelegates
-	undelegateAmount := vacc.DelegatedVesting.AmountOf(bondDenom)
-	fmt.Printf("DelegatedVesting before: %v\n", undelegateAmount)
-	vacc.TrackUndelegation(vacc.DelegatedVesting)
-	fmt.Printf("DelegatedVesting after: %v\n", vacc.DelegatedVesting)
-
-	vacc.BaseVestingAccount.EndTime = now.Unix() - 1
-
-	stdbal := keepers.BankKeeper.GetBalance(ctx, accAddr, bondDenom)
-	fmt.Printf("stdbal before: %v\n", stdbal)
-
-	if err := keepers.BankKeeper.SendCoinsFromAccountToModule(ctx, accAddr, distrtypes.ModuleName, sdk.NewCoins(stdbal)); err != nil {
-		panic(err)
-	}
-
-	// then transfer that to core 1 fgrom ModuleToAccount
-	if err := keepers.BankKeeper.SendCoinsFromModuleToAccount(ctx, distrtypes.ModuleName, sdk.AccAddress(core1SubDaoAddress), sdk.NewCoins(stdbal)); err != nil {
-		panic(err)
-	}
-
-	// TODO: vesting
-
-	// get current held balance from stdAcc
-	stdbal = keepers.BankKeeper.GetBalance(ctx, accAddr, bondDenom)
-	fmt.Printf("stdbal after: %v\n", stdbal)
-
-	// get balance of core1 (needs to be the original vesting ammount)
-	core1Bal = keepers.BankKeeper.GetBalance(ctx, sdk.AccAddress(core1SubDaoAddress), bondDenom)
-	fmt.Printf("core1Bal: %v\n", core1Bal)
-
-	// print out vacc
-	fmt.Printf("MoveVestingCoinFromVestingAccount: %s\n", vacc)
-
-	return core1Bal, nil
-	// return sdk.Coin{}, fmt.Errorf("not implemented")
-
-	// // get balance of accAddr
-	// bal := (&keepers.BankKeeper).GetBalance(ctx, accAddr, bondDenom)
-	// fmt.Printf("MoveVestingCoinFromVestingAccount: %s\n", bal)
-	// // account info
-	// accInfo := (&keepers.AccountKeeper).GetAccount(ctx, accAddr)
-	// fmt.Printf("MoveVestingCoinFromVestingAccount: %s\n", accInfo)
-	// for _, delegation := range keepers.StakingKeeper.GetAllDelegatorDelegations(ctx, accAddr) {
-	// 	validatorValAddr := delegation.GetValidatorAddr()
-	// 	_, found := keepers.StakingKeeper.GetValidator(ctx, validatorValAddr)
-	// 	if !found {
-	// 		continue
-	// 	}
-	// 	fmt.Printf("MoveVestingCoinFromVestingAccount: %s\n", delegation)
-	// 	// _, err := keepers.StakingKeeper.Undelegate(ctx, accAddr, validatorValAddr, delegation.GetShares())
-	// 	// if err != nil {
-	// 	// 	panic(err)
-	// 	// }
-	// }
-	// return sdk.Coin{}, fmt.Errorf("not implemented")
-
-	// TODO: Is this needed?
-	// Complete any active re-delegations
-	// for _, activeRedelegation := range keepers.StakingKeeper.GetRedelegations(ctx, accAddr, 65535) {
-	// 	redelegationSrc, _ := sdk.ValAddressFromBech32(activeRedelegation.ValidatorSrcAddress)
-	// 	redelegationDst, _ := sdk.ValAddressFromBech32(activeRedelegation.ValidatorDstAddress)
-
-	// 	// set all entry completionTime to now so we can complete redelegation
-	// 	for i := range activeRedelegation.Entries {
-	// 		activeRedelegation.Entries[i].CompletionTime = now
-	// 	}
-
-	// 	keepers.StakingKeeper.SetRedelegation(ctx, activeRedelegation)
-	// 	_, err := keepers.StakingKeeper.CompleteRedelegation(ctx, accAddr, redelegationSrc, redelegationDst)
-	// 	if err != nil {
-	// 		panic(err)
-	// 	}
-	// }
-
-	// Complete all delegator's unbonding delegations
-	for _, unbondingDelegation := range keepers.StakingKeeper.GetAllUnbondingDelegations(ctx, accAddr) {
-		validatorStringAddr := unbondingDelegation.ValidatorAddress
-		validatorValAddr, _ := sdk.ValAddressFromBech32(validatorStringAddr)
-
-		// Complete unbonding delegation
-		for i := range unbondingDelegation.Entries {
-			unbondingDelegation.Entries[i].CompletionTime = now
-		}
-		keepers.StakingKeeper.SetUnbondingDelegation(ctx, unbondingDelegation)
-		_, err := keepers.StakingKeeper.CompleteUnbonding(ctx, accAddr, validatorValAddr)
-		if err != nil {
-			panic(err)
-		}
-	}
-
-	// account balance after finishing unbonding
-	accCoin := keepers.BankKeeper.GetBalance(ctx, accAddr, bondDenom)
-
-	vacc.OriginalVesting = vacc.OriginalVesting.Add(accCoin)
-
-	// make entire balance spendable
-	// keepers.AccountKeeper.SetAccount(ctx, )
-
-	// Send coin to Core-1 subDao for holding on behalf of the core-1 members
-	destAcc, _ := sdk.AccAddressFromBech32(core1SubDaoAddress)
-	err = keepers.BankKeeper.SendCoins(ctx, accAddr, destAcc, sdk.NewCoins(accCoin))
-	if err != nil {
-		panic(err)
-	}
-
-	ctx.Logger().Info("MoveVestingCoinFromVestingAccount", "account", accAddr.String(), "amount", accCoin)
-
-	// return accCoin, nil
-	return accCoin, fmt.Errorf("not implemented")
+	// return sdk.Coin{}, fmt.Errorf("not implemented MoveVestingCoinFromVestAccount")
+	return sdk.Coin{}, nil
 }

--- a/app/upgrades/vesting.go
+++ b/app/upgrades/vesting.go
@@ -32,11 +32,8 @@ func MoveVestingCoinFromVestingAccount(ctx sdk.Context, keepers *keepers.AppKeep
 	unvestedCoins := getStillVestingCoins(vacc, now)
 	fmt.Printf("Locked / waiting to vest Coins: %v\n", unvestedCoins)
 
-	// Get Core1 and Vesting account balances before migration
+	// Get Core1 and before migration
 	core1BeforeBal := keepers.BankKeeper.GetBalance(ctx, core1AccAddr, bondDenom)
-	// beforeBal := keepers.BankKeeper.GetBalance(ctx, accAddr, bondDenom) // cant do anything with before block rewards.
-	// fmt.Printf("Core1 SubDAO Balance: %v\n", core1BeforeBal)
-	// fmt.Printf("Vesting Account Balance: %v\n", beforeBal)
 
 	// Clears the account so all all future vesting periods are removed.
 	// Sets it as a standard base account.
@@ -154,7 +151,6 @@ func unbondAllAndFinish(ctx sdk.Context, now time.Time, keepers *keepers.AppKeep
 		if err != nil {
 			return math.ZeroInt(), err
 		}
-		// fmt.Printf("time: %s and err:%v\n", time, err)
 	}
 
 	// Take all unbonding and complete them.

--- a/app/upgrades/vesting.go
+++ b/app/upgrades/vesting.go
@@ -19,7 +19,9 @@ func MoveVestingCoinFromVestingAccount(ctx sdk.Context, accAddr sdk.AccAddress, 
 	stdAcc := keepers.AccountKeeper.GetAccount(ctx, accAddr)
 	vacc, ok := stdAcc.(*authvestingtypes.ContinuousVestingAccount)
 	if !ok {
-		return fmt.Errorf("account is not a vesting account")
+		// For e2e testing
+		fmt.Printf("account " + accAddr.String() + " is not a vesting account\n")
+		return nil
 	}
 
 	// Shows locked funds

--- a/app/upgrades/vesting.go
+++ b/app/upgrades/vesting.go
@@ -4,39 +4,106 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/CosmosContracts/juno/v16/app/keepers"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-
 	authvestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
+
+	"github.com/CosmosContracts/juno/v16/app/keepers"
 )
 
-// TODO: Redelegations check as well.
-func undelegate(ctx sdk.Context, now time.Time, keepers *keepers.AppKeepers, accAddr sdk.AccAddress, vacc *authvestingtypes.ContinuousVestingAccount) error {
-	// Unbond all delegations from the account
-	delegations := keepers.StakingKeeper.GetAllDelegatorDelegations(ctx, accAddr)
+// Stops a vesting account and returns all tokens back to the Core-1 subdao.
+func MoveVestingCoinFromVestingAccount(ctx sdk.Context, accAddr sdk.AccAddress, keepers *keepers.AppKeepers, core1SubDaoAddress string, bondDenom string) error {
+	now := ctx.BlockHeader().Time
 
-	for _, delegation := range delegations {
+	core1AccAddr := sdk.MustAccAddressFromBech32(core1SubDaoAddress)
+
+	stdAcc := keepers.AccountKeeper.GetAccount(ctx, accAddr)
+	vacc, ok := stdAcc.(*authvestingtypes.ContinuousVestingAccount)
+	if !ok {
+		return fmt.Errorf("account is not a vesting account")
+	}
+
+	// Shows locked funds
+	showLockedCoins(vacc, now)
+
+	// Finish vesting period now.
+	vacc.EndTime = 1
+	vacc.BaseVestingAccount.EndTime = 1
+	keepers.AccountKeeper.SetAccount(ctx, vacc)
+
+	// Set it so any re-delegations are finished.
+	if err := completeAllRedelegations(ctx, keepers, accAddr, now); err != nil {
+		return err
+	}
+
+	// Instant unbond all delegations
+	// TODO: What about rewards?
+	if err := unbondAllAndFinish(ctx, now, keepers, accAddr); err != nil {
+		return err
+	}
+
+	// Get balance
+	accbal := keepers.BankKeeper.GetBalance(ctx, accAddr, bondDenom)
+	fmt.Printf("bal: %v\n", accbal)
+
+	// Send all tokens from balance to the core-1 subdao address
+	if e := keepers.BankKeeper.SendCoins(ctx, accAddr, core1AccAddr, sdk.NewCoins(accbal)); e != nil {
+		return fmt.Errorf("error sending coins: %v", e)
+	}
+
+	// get bal of core1SubDaoAddress
+	core1BalC := keepers.BankKeeper.GetBalance(ctx, sdk.MustAccAddressFromBech32(core1SubDaoAddress), bondDenom)
+	fmt.Printf("core1Bal: %v\n", core1BalC)
+
+	// get balance of accAddr
+	accbal = keepers.BankKeeper.GetBalance(ctx, accAddr, bondDenom)
+	fmt.Printf("bal: %v\n", accbal)
+
+	// TODO: Delete said account? (no reason to have it or the base account anymore yea? any issues of doing this?)
+	// if so, do we have to remove all the subAccounts first of the vacc/
+	keepers.AccountKeeper.RemoveAccount(ctx, vacc)
+
+	// return sdk.Coin{}, fmt.Errorf("not implemented MoveVestingCoinFromVestAccount")
+	return nil
+}
+
+func completeAllRedelegations(ctx sdk.Context, keepers *keepers.AppKeepers, accAddr sdk.AccAddress, now time.Time) error {
+	for _, activeRedelegation := range keepers.StakingKeeper.GetRedelegations(ctx, accAddr, 65535) {
+		redelegationSrc, _ := sdk.ValAddressFromBech32(activeRedelegation.ValidatorSrcAddress)
+		redelegationDst, _ := sdk.ValAddressFromBech32(activeRedelegation.ValidatorDstAddress)
+
+		// set all entry completionTime to now so we can complete re-delegation
+		for i := range activeRedelegation.Entries {
+			activeRedelegation.Entries[i].CompletionTime = now
+		}
+
+		keepers.StakingKeeper.SetRedelegation(ctx, activeRedelegation)
+		_, err := keepers.StakingKeeper.CompleteRedelegation(ctx, accAddr, redelegationSrc, redelegationDst)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func unbondAllAndFinish(ctx sdk.Context, now time.Time, keepers *keepers.AppKeepers, accAddr sdk.AccAddress) error {
+	// Unbond all delegations from the account
+	for _, delegation := range keepers.StakingKeeper.GetAllDelegatorDelegations(ctx, accAddr) {
 		validatorValAddr := delegation.GetValidatorAddr()
 		_, found := keepers.StakingKeeper.GetValidator(ctx, validatorValAddr)
 		if !found {
 			continue
 		}
 
-		// fmt.Printf("delegation: %s\n", delegation)
-		// fmt.Printf("validatorValAddr: %s\n", validatorValAddr)
-
-		// vacc.TrackUndelegation(vacc.DelegatedVesting) ??
-		time, err := (*keepers.StakingKeeper).Undelegate(ctx, accAddr, validatorValAddr, delegation.GetShares())
+		time, err := keepers.StakingKeeper.Undelegate(ctx, accAddr, validatorValAddr, delegation.GetShares())
 		if err != nil {
 			return err
 		}
 		fmt.Printf("time: %s and err:%v\n", time, err)
 	}
 
-	unbonding := keepers.StakingKeeper.GetAllUnbondingDelegations(ctx, accAddr)
-	// fmt.Printf("unbonding: %s\n", unbonding)
-
-	for _, unbondingDelegation := range unbonding {
+	// Take all unbonding and complete them.
+	for _, unbondingDelegation := range keepers.StakingKeeper.GetAllUnbondingDelegations(ctx, accAddr) {
 		validatorStringAddr := unbondingDelegation.ValidatorAddress
 		validatorValAddr, _ := sdk.ValAddressFromBech32(validatorStringAddr)
 
@@ -52,72 +119,12 @@ func undelegate(ctx sdk.Context, now time.Time, keepers *keepers.AppKeepers, acc
 		}
 	}
 
-	// check there are no more delegations.
-	delegations = keepers.StakingKeeper.GetAllDelegatorDelegations(ctx, accAddr)
-	if len(delegations) > 0 {
-		panic("delegations not empty")
-	}
-
 	return nil
 }
 
-func checkLockedCoins(vacc *authvestingtypes.ContinuousVestingAccount, now time.Time) sdk.Coins {
+func showLockedCoins(vacc *authvestingtypes.ContinuousVestingAccount, now time.Time) {
 	locked := vacc.LockedCoins(now)
 	lockedFromVesting := vacc.LockedCoinsFromVesting(vacc.GetVestingCoins(now))
 	fmt.Printf("locked: %v\n", locked)
 	fmt.Printf("lockedVesting: %v\n", lockedFromVesting)
-	return locked
-}
-
-// Stops a vesting account and returns all tokens back to the Core-1 subdao.
-func MoveVestingCoinFromVestingAccount(ctx sdk.Context, accAddr sdk.AccAddress, keepers *keepers.AppKeepers, core1SubDaoAddress string, bondDenom string) (sdk.Coin, error) {
-	// var err error
-
-	now := ctx.BlockHeader().Time
-
-	core1AccAddr := sdk.MustAccAddressFromBech32(core1SubDaoAddress)
-
-	stdAcc := keepers.AccountKeeper.GetAccount(ctx, accAddr)
-	vacc, ok := stdAcc.(*authvestingtypes.ContinuousVestingAccount)
-	if !ok {
-		panic("not a ContinuousVestingAccount vesting account")
-	}
-
-	// should show numbers
-	l := checkLockedCoins(vacc, now)
-	fmt.Printf("l: %v\n", l)
-
-	// Finish vesting period now.
-	vacc.EndTime = 1
-	vacc.BaseVestingAccount.EndTime = 1
-	keepers.AccountKeeper.SetAccount(ctx, vacc)
-
-	// Instant unbond all tokens, goes into balance.
-	if err := undelegate(ctx, now, keepers, accAddr, vacc); err != nil {
-		return sdk.Coin{}, err
-	}
-
-	// Get balance
-	accbal := keepers.BankKeeper.GetBalance(ctx, accAddr, bondDenom)
-	fmt.Printf("bal: %v\n", accbal)
-
-	// Send all tokens from balance to the core-1 subdao address
-	if e := keepers.BankKeeper.SendCoins(ctx, accAddr, core1AccAddr, sdk.NewCoins(accbal)); e != nil {
-		return sdk.Coin{}, fmt.Errorf("error sending coins: %v", e)
-	}
-
-	// get bal of core1SubDaoAddress
-	core1BalC := keepers.BankKeeper.GetBalance(ctx, sdk.MustAccAddressFromBech32(core1SubDaoAddress), bondDenom)
-	fmt.Printf("core1Bal: %v\n", core1BalC)
-
-	// get balance of accAddr
-	accbal = keepers.BankKeeper.GetBalance(ctx, accAddr, bondDenom)
-	fmt.Printf("bal: %v\n", accbal)
-
-	// TODO: Delete said account? (no reason to have it or the abse account anymore yea? any issues of doing this?)
-	// if so, do we have to remove all the subAccounts first of the vacc/
-	keepers.AccountKeeper.RemoveAccount(ctx, vacc)
-
-	// return sdk.Coin{}, fmt.Errorf("not implemented MoveVestingCoinFromVestAccount")
-	return sdk.Coin{}, nil
 }

--- a/app/upgrades/vesting.go
+++ b/app/upgrades/vesting.go
@@ -1,0 +1,245 @@
+package upgrades
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/CosmosContracts/juno/v16/app/keepers"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	authvestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+)
+
+func undelegate(ctx sdk.Context, now time.Time, keepers *keepers.AppKeepers, accAddr sdk.AccAddress, vacc *authvestingtypes.ContinuousVestingAccount) error {
+	// Unbond all delegations from the account
+	delegations := keepers.StakingKeeper.GetAllDelegatorDelegations(ctx, accAddr)
+
+	for _, delegation := range delegations {
+		validatorValAddr := delegation.GetValidatorAddr()
+		_, found := keepers.StakingKeeper.GetValidator(ctx, validatorValAddr)
+		if !found {
+			continue
+		}
+
+		// fmt.Printf("delegation: %s\n", delegation)
+		// fmt.Printf("validatorValAddr: %s\n", validatorValAddr)
+
+		// vacc.TrackUndelegation(vacc.DelegatedVesting) ??
+		time, err := (*keepers.StakingKeeper).Undelegate(ctx, accAddr, validatorValAddr, delegation.GetShares())
+		if err != nil {
+			return err
+		}
+		fmt.Printf("time: %s and err:%v\n", time, err)
+	}
+
+	unbonding := keepers.StakingKeeper.GetAllUnbondingDelegations(ctx, accAddr)
+	// fmt.Printf("unbonding: %s\n", unbonding)
+
+	for _, unbondingDelegation := range unbonding {
+		validatorStringAddr := unbondingDelegation.ValidatorAddress
+		validatorValAddr, _ := sdk.ValAddressFromBech32(validatorStringAddr)
+
+		// Complete unbonding delegation
+		for i := range unbondingDelegation.Entries {
+			unbondingDelegation.Entries[i].CompletionTime = now
+		}
+
+		keepers.StakingKeeper.SetUnbondingDelegation(ctx, unbondingDelegation)
+		_, err := keepers.StakingKeeper.CompleteUnbonding(ctx, accAddr, validatorValAddr)
+		if err != nil {
+			return err
+		}
+	}
+
+	// check there are no more delegations.
+	delegations = keepers.StakingKeeper.GetAllDelegatorDelegations(ctx, accAddr)
+	if len(delegations) > 0 {
+		panic("delegations not empty")
+	}
+
+	return nil
+}
+
+func checkLockedCoins(vacc *authvestingtypes.ContinuousVestingAccount, now time.Time) sdk.Coins {
+	locked := vacc.LockedCoins(now)
+	locakedVesting := vacc.LockedCoinsFromVesting(vacc.GetVestingCoins(now))
+	fmt.Printf("locked: %v\n", locked)
+	fmt.Printf("locakedVesting: %v\n", locakedVesting)
+	return locked
+}
+
+// Undelegates all tokens, and send it back to the core1 subdao address for the vesting contract to instantiate
+func MoveVestingCoinFromVestingAccount(ctx sdk.Context, accAddr sdk.AccAddress, keepers *keepers.AppKeepers, core1SubDaoAddress string, bondDenom string) (sdk.Coin, error) {
+	var err error
+
+	now := ctx.BlockHeader().Time
+
+	stdAcc := keepers.AccountKeeper.GetAccount(ctx, accAddr)
+	vacc, ok := stdAcc.(*authvestingtypes.ContinuousVestingAccount)
+	if !ok {
+		panic("not a ContinuousVestingAccount vesting account")
+	}
+
+	// should show numbers
+	l := checkLockedCoins(vacc, now)
+	fmt.Printf("l: %v\n", l)
+
+	// set end time to now to unlock.
+	vacc.EndTime = now.Unix() - 1_000_000
+	vacc.BaseVestingAccount.EndTime = now.Unix() - 1_000_000
+	// vacc.DelegatedFree = sdk.NewCoins()
+	// vacc.DelegatedVesting = sdk.NewCoins()
+	// vacc.OriginalVesting = sdk.NewCoins()
+	// vacc.BaseVestingAccount.DelegatedFree = sdk.NewCoins()
+	// vacc.BaseVestingAccount.DelegatedVesting = sdk.NewCoins()
+	// vacc.BaseVestingAccount.OriginalVesting = sdk.NewCoins()
+
+	// Nothing shown here.
+	checkLockedCoins(vacc, now)
+
+	// undelegate all.
+	if err := undelegate(ctx, now, keepers, accAddr, vacc); err != nil {
+		return sdk.Coin{}, err
+	}
+
+	bal := keepers.BankKeeper.GetBalance(ctx, accAddr, bondDenom)
+	fmt.Printf("Balance: %s\n", bal)
+	if err := keepers.BankKeeper.SendCoinsFromAccountToModule(ctx, accAddr, distrtypes.ModuleName, sdk.NewCoins(bal)); err != nil {
+		return sdk.Coin{}, err
+	}
+
+	// get distrtypes.ModuleName balance
+	distrtypesModuleBalance := keepers.BankKeeper.GetBalance(ctx, sdk.AccAddress(distrtypes.ModuleName), bondDenom)
+	fmt.Printf("distrtypesModuleBalance: %v\n", distrtypesModuleBalance)
+
+	// update vacc to be entirely spendable
+	// vacc.DelegatedFree = sdk.NewCoins(bal)
+	// vacc.BaseVestingAccount.DelegatedFree = sdk.NewCoins(bal)
+
+	fmt.Printf("MoveVestingCoinFromVestingAccount: %s\n", vacc)
+
+	// send funds since they are unlocked.
+	// spendable balance here is nil.
+	fmt.Print("sending\n", keepers.BankKeeper.GetBalance(ctx, accAddr, bondDenom))
+	if err := keepers.BankKeeper.SendCoins(ctx, accAddr, sdk.AccAddress(core1SubDaoAddress), sdk.NewCoins(bal)); err != nil {
+		return sdk.Coin{}, err
+	}
+
+	fmt.Printf("MoveVestingCoinFromVestingAccount: %s\n", vacc)
+
+	core1Bal := keepers.BankKeeper.GetBalance(ctx, sdk.AccAddress(core1SubDaoAddress), bondDenom)
+	fmt.Printf("core1Bal: %v\n", core1Bal)
+
+	return sdk.Coin{}, fmt.Errorf("not implemented")
+
+	// undelegates
+	undelegateAmount := vacc.DelegatedVesting.AmountOf(bondDenom)
+	fmt.Printf("DelegatedVesting before: %v\n", undelegateAmount)
+	vacc.TrackUndelegation(vacc.DelegatedVesting)
+	fmt.Printf("DelegatedVesting after: %v\n", vacc.DelegatedVesting)
+
+	vacc.BaseVestingAccount.EndTime = now.Unix() - 1
+
+	stdbal := keepers.BankKeeper.GetBalance(ctx, accAddr, bondDenom)
+	fmt.Printf("stdbal before: %v\n", stdbal)
+
+	if err := keepers.BankKeeper.SendCoinsFromAccountToModule(ctx, accAddr, distrtypes.ModuleName, sdk.NewCoins(stdbal)); err != nil {
+		panic(err)
+	}
+
+	// then transfer that to core 1 fgrom ModuleToAccount
+	if err := keepers.BankKeeper.SendCoinsFromModuleToAccount(ctx, distrtypes.ModuleName, sdk.AccAddress(core1SubDaoAddress), sdk.NewCoins(stdbal)); err != nil {
+		panic(err)
+	}
+
+	// TODO: vesting
+
+	// get current held balance from stdAcc
+	stdbal = keepers.BankKeeper.GetBalance(ctx, accAddr, bondDenom)
+	fmt.Printf("stdbal after: %v\n", stdbal)
+
+	// get balance of core1 (needs to be the original vesting ammount)
+	core1Bal = keepers.BankKeeper.GetBalance(ctx, sdk.AccAddress(core1SubDaoAddress), bondDenom)
+	fmt.Printf("core1Bal: %v\n", core1Bal)
+
+	// print out vacc
+	fmt.Printf("MoveVestingCoinFromVestingAccount: %s\n", vacc)
+
+	return core1Bal, nil
+	// return sdk.Coin{}, fmt.Errorf("not implemented")
+
+	// // get balance of accAddr
+	// bal := (&keepers.BankKeeper).GetBalance(ctx, accAddr, bondDenom)
+	// fmt.Printf("MoveVestingCoinFromVestingAccount: %s\n", bal)
+	// // account info
+	// accInfo := (&keepers.AccountKeeper).GetAccount(ctx, accAddr)
+	// fmt.Printf("MoveVestingCoinFromVestingAccount: %s\n", accInfo)
+	// for _, delegation := range keepers.StakingKeeper.GetAllDelegatorDelegations(ctx, accAddr) {
+	// 	validatorValAddr := delegation.GetValidatorAddr()
+	// 	_, found := keepers.StakingKeeper.GetValidator(ctx, validatorValAddr)
+	// 	if !found {
+	// 		continue
+	// 	}
+	// 	fmt.Printf("MoveVestingCoinFromVestingAccount: %s\n", delegation)
+	// 	// _, err := keepers.StakingKeeper.Undelegate(ctx, accAddr, validatorValAddr, delegation.GetShares())
+	// 	// if err != nil {
+	// 	// 	panic(err)
+	// 	// }
+	// }
+	// return sdk.Coin{}, fmt.Errorf("not implemented")
+
+	// TODO: Is this needed?
+	// Complete any active re-delegations
+	// for _, activeRedelegation := range keepers.StakingKeeper.GetRedelegations(ctx, accAddr, 65535) {
+	// 	redelegationSrc, _ := sdk.ValAddressFromBech32(activeRedelegation.ValidatorSrcAddress)
+	// 	redelegationDst, _ := sdk.ValAddressFromBech32(activeRedelegation.ValidatorDstAddress)
+
+	// 	// set all entry completionTime to now so we can complete redelegation
+	// 	for i := range activeRedelegation.Entries {
+	// 		activeRedelegation.Entries[i].CompletionTime = now
+	// 	}
+
+	// 	keepers.StakingKeeper.SetRedelegation(ctx, activeRedelegation)
+	// 	_, err := keepers.StakingKeeper.CompleteRedelegation(ctx, accAddr, redelegationSrc, redelegationDst)
+	// 	if err != nil {
+	// 		panic(err)
+	// 	}
+	// }
+
+	// Complete all delegator's unbonding delegations
+	for _, unbondingDelegation := range keepers.StakingKeeper.GetAllUnbondingDelegations(ctx, accAddr) {
+		validatorStringAddr := unbondingDelegation.ValidatorAddress
+		validatorValAddr, _ := sdk.ValAddressFromBech32(validatorStringAddr)
+
+		// Complete unbonding delegation
+		for i := range unbondingDelegation.Entries {
+			unbondingDelegation.Entries[i].CompletionTime = now
+		}
+		keepers.StakingKeeper.SetUnbondingDelegation(ctx, unbondingDelegation)
+		_, err := keepers.StakingKeeper.CompleteUnbonding(ctx, accAddr, validatorValAddr)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	// account balance after finishing unbonding
+	accCoin := keepers.BankKeeper.GetBalance(ctx, accAddr, bondDenom)
+
+	vacc.OriginalVesting = vacc.OriginalVesting.Add(accCoin)
+
+	// make entire balance spendable
+	// keepers.AccountKeeper.SetAccount(ctx, )
+
+	// Send coin to Core-1 subDao for holding on behalf of the core-1 members
+	destAcc, _ := sdk.AccAddressFromBech32(core1SubDaoAddress)
+	err = keepers.BankKeeper.SendCoins(ctx, accAddr, destAcc, sdk.NewCoins(accCoin))
+	if err != nil {
+		panic(err)
+	}
+
+	ctx.Logger().Info("MoveVestingCoinFromVestingAccount", "account", accAddr.String(), "amount", accCoin)
+
+	// return accCoin, nil
+	return accCoin, fmt.Errorf("not implemented")
+}

--- a/interchaintest/chain_upgrade_test.go
+++ b/interchaintest/chain_upgrade_test.go
@@ -100,12 +100,12 @@ func CosmosChainUpgradeTest(t *testing.T, chainName, initialVersion, upgradeBran
 	chainUser := users[0]
 
 	// create a tokenfactory denom before upgrade (invalid genesis for hard forking due to x/bank validation)
-	emptyFullDenom := helpers.CreateTokenFactoryDenom(t, ctx, chain, chainUser, "empty")
+	emptyFullDenom := helpers.CreateTokenFactoryDenom(t, ctx, chain, chainUser, "empty", "")
 
-	mintedDenom := helpers.CreateTokenFactoryDenom(t, ctx, chain, chainUser, "minted")
+	mintedDenom := helpers.CreateTokenFactoryDenom(t, ctx, chain, chainUser, "minted", "")
 	helpers.MintToTokenFactoryDenom(t, ctx, chain, chainUser, chainUser, 100, mintedDenom)
 
-	mintedAndModified := helpers.CreateTokenFactoryDenom(t, ctx, chain, chainUser, "mandm")
+	mintedAndModified := helpers.CreateTokenFactoryDenom(t, ctx, chain, chainUser, "mandm", "")
 	helpers.MintToTokenFactoryDenom(t, ctx, chain, chainUser, chainUser, 100, mintedAndModified)
 
 	ticker, desc, exponent := "TICKER", "desc", "6"
@@ -222,7 +222,8 @@ func CosmosChainUpgradeTest(t *testing.T, chainName, initialVersion, upgradeBran
 	require.Equal(t, postModified, modifiedRes)
 
 	// Ensure after the upgrade, the denoms are properly set with the Denom Metadata.
-	afterUpgrade := helpers.CreateTokenFactoryDenom(t, ctx, chain, chainUser, "post")
+	// (Due to migrating hardcoded, we have to set a fee after the upgrade).
+	afterUpgrade := helpers.CreateTokenFactoryDenom(t, ctx, chain, chainUser, "post", "250000"+Denom)
 	newRes := helpers.GetTokenFactoryDenomMetadata(t, ctx, chain, afterUpgrade)
 	require.Equal(t, newRes.Display, afterUpgrade)
 	require.Equal(t, newRes.Name, afterUpgrade)

--- a/interchaintest/helpers/tokenfactory.go
+++ b/interchaintest/helpers/tokenfactory.go
@@ -36,7 +36,7 @@ func CreateTokenFactoryDenom(t *testing.T, ctx context.Context, chain *cosmos.Co
 		"-y",
 	}
 
-	if feeCoin == "" {
+	if feeCoin != "" {
 		cmd = append(cmd, "--fees", feeCoin)
 	}
 

--- a/interchaintest/helpers/tokenfactory.go
+++ b/interchaintest/helpers/tokenfactory.go
@@ -23,7 +23,7 @@ func debugOutput(t *testing.T, stdout string) {
 	}
 }
 
-func CreateTokenFactoryDenom(t *testing.T, ctx context.Context, chain *cosmos.CosmosChain, user ibc.Wallet, subDenomName string) (fullDenom string) {
+func CreateTokenFactoryDenom(t *testing.T, ctx context.Context, chain *cosmos.CosmosChain, user ibc.Wallet, subDenomName, feeCoin string) (fullDenom string) {
 	// TF gas to create cost 2mil, so we set to 2.5 to be safe
 	cmd := []string{"junod", "tx", "tokenfactory", "create-denom", subDenomName,
 		"--node", chain.GetRPCAddress(),
@@ -31,11 +31,15 @@ func CreateTokenFactoryDenom(t *testing.T, ctx context.Context, chain *cosmos.Co
 		"--chain-id", chain.Config().ChainID,
 		"--from", user.KeyName(),
 		"--gas", "2500000",
-		"--gas-adjustment", "2.0",
 		"--keyring-dir", chain.HomeDir(),
 		"--keyring-backend", keyring.BackendTest,
 		"-y",
 	}
+
+	if feeCoin == "" {
+		cmd = append(cmd, "--fees", feeCoin)
+	}
+
 	stdout, _, err := chain.Exec(ctx, cmd, nil)
 	require.NoError(t, err)
 

--- a/interchaintest/module_tokenfactory_test.go
+++ b/interchaintest/module_tokenfactory_test.go
@@ -29,7 +29,7 @@ func TestJunoTokenFactory(t *testing.T) {
 	user2 := users[1]
 	uaddr2 := user2.FormattedAddress()
 
-	tfDenom := helpers.CreateTokenFactoryDenom(t, ctx, juno, user, "ictestdenom")
+	tfDenom := helpers.CreateTokenFactoryDenom(t, ctx, juno, user, "ictestdenom", fmt.Sprintf("0%s", Denom))
 	t.Log("tfDenom", tfDenom)
 
 	// mint

--- a/x/globalfee/migrations/v2/migrator_test.go
+++ b/x/globalfee/migrations/v2/migrator_test.go
@@ -10,22 +10,9 @@ import (
 	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
 
 	"github.com/CosmosContracts/juno/v16/x/globalfee"
-	"github.com/CosmosContracts/juno/v16/x/globalfee/keeper/exported"
 	v2 "github.com/CosmosContracts/juno/v16/x/globalfee/migrations/v2"
 	"github.com/CosmosContracts/juno/v16/x/globalfee/types"
 )
-
-type mockSubspace struct {
-	ps types.Params
-}
-
-func newMockSubspace(ps types.Params) mockSubspace {
-	return mockSubspace{ps: ps}
-}
-
-func (ms mockSubspace) GetParamSet(_ sdk.Context, ps exported.ParamSet) {
-	*ps.(*types.Params) = ms.ps
-}
 
 func TestMigrateMainnet(t *testing.T) {
 	encCfg := moduletestutil.MakeTestEncodingConfig(globalfee.AppModuleBasic{})


### PR DESCRIPTION
Runs the following when chain-id == "juno-1":

- Unlock all tokens (end time of epoch time 1)
- Force finish any redelegations
- Force Unbond all current delegations
- Get balance
- Send to Core1 subDAO

TODO:
- Need to add standard logic checks to ensure this works properly. Can re-use for all Core-1 -> vesting contracts.
- Just do it for all Core-1 members from the other PR? (And init contracts on their behalf)