### PR TITLE
remove myself from security.md in a visible way

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,7 +27,6 @@ If you're here because you're trying to figure out how to notify us of a securit
 - Jake (Meow) `Meow Stargaze ✨🔭#1736`
 - Dimi `dimi 🦙#2998`
 - Alex (the-frey) `the-frey#8626`
-- Jacob `jacobgadikian#9883`
 - Giansalex `giansalex#1825`
 - Reece `Reece#3370`
 


### PR DESCRIPTION
This PR removes me from Juno's security contacts in a visible way, instead of being bundled into another changeset as in #692 