### PR TITLE
[v17] Refactor ICTest e2e upgrades

### DIFF
--- a/interchaintest/chain_upgrade_test.go
+++ b/interchaintest/chain_upgrade_test.go
@@ -6,12 +6,15 @@ import (
 	"testing"
 	"time"
 
+	cosmosproto "github.com/cosmos/gogoproto/proto"
+	"github.com/docker/docker/client"
 	"github.com/strangelove-ventures/interchaintest/v7"
 	"github.com/strangelove-ventures/interchaintest/v7/chain/cosmos"
 	"github.com/strangelove-ventures/interchaintest/v7/ibc"
 	"github.com/strangelove-ventures/interchaintest/v7/testutil"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zaptest"
+
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 )
 
 const (
@@ -35,60 +38,11 @@ func CosmosChainUpgradeTest(t *testing.T, chainName, initialVersion, upgradeBran
 
 	t.Log(chainName, initialVersion, upgradeBranchVersion, upgradeRepo, upgradeName)
 
-	// v45 genesis params
-	genesisKVs := []cosmos.GenesisKV{
-		{
-			Key:   "app_state.gov.voting_params.voting_period",
-			Value: VotingPeriod,
-		},
-		{
-			Key:   "app_state.gov.deposit_params.max_deposit_period",
-			Value: MaxDepositPeriod,
-		},
-		{
-			Key:   "app_state.gov.deposit_params.min_deposit.0.denom",
-			Value: Denom,
-		},
-	}
-
-	cf := interchaintest.NewBuiltinChainFactory(zaptest.NewLogger(t), []*interchaintest.ChainSpec{
-		{
-			Name:      chainName,
-			ChainName: chainName,
-			Version:   initialVersion,
-			ChainConfig: ibc.ChainConfig{
-				Images: []ibc.DockerImage{
-					{
-						Repository: JunoE2ERepo,
-						Version:    initialVersion,
-						UidGid:     JunoImage.UidGid,
-					},
-				},
-				GasPrices:              fmt.Sprintf("0%s", Denom),
-				ModifyGenesis:          cosmos.ModifyGenesis(genesisKVs),
-				UsingNewGenesisCommand: true, // SDK v47
-			},
-		},
-	})
-
-	chains, err := cf.Chains(t.Name())
-	require.NoError(t, err)
-
+	numVals, numNodes := 4, 4
+	chains := CreateThisBranchChain(t, numVals, numNodes)
 	chain := chains[0].(*cosmos.CosmosChain)
 
-	ic := interchaintest.NewInterchain().
-		AddChain(chain)
-
-	ctx := context.Background()
-	client, network := interchaintest.DockerSetup(t)
-
-	err = ic.Build(ctx, nil, interchaintest.InterchainBuildOptions{
-		TestName:         t.Name(),
-		Client:           client,
-		NetworkID:        network,
-		SkipPathCreation: true,
-	})
-	require.NoError(t, err)
+	ic, ctx, client, _ := BuildInitialChain(t, chains)
 
 	t.Cleanup(func() {
 		_ = ic.Close()
@@ -103,22 +57,48 @@ func CosmosChainUpgradeTest(t *testing.T, chainName, initialVersion, upgradeBran
 	require.NoError(t, err, "error fetching height before submit upgrade proposal")
 
 	haltHeight := height + haltHeightDelta
+	proposalID := SubmitUpgradeProposal(t, ctx, chain, chainUser, upgradeName, haltHeight)
 
-	proposal := cosmos.SoftwareUpgradeProposal{
-		Deposit:     "500000000" + chain.Config().Denom, // greater than min deposit
-		Title:       "Chain Upgrade 1",
-		Name:        upgradeName,
-		Description: "First chain software upgrade",
-		Height:      haltHeight,
-	}
+	ValidatorVoting(t, ctx, chain, proposalID, height, haltHeight)
 
-	upgradeTx, err := chain.UpgradeProposal(ctx, chainUser.KeyName(), proposal)
-	require.NoError(t, err, "error submitting software upgrade proposal tx")
+	UpgradeNodes(t, ctx, chain, client, haltHeight, upgradeRepo, upgradeBranchVersion)
 
-	err = chain.VoteOnProposalAllValidators(ctx, upgradeTx.ProposalID, cosmos.ProposalVoteYes)
+}
+
+func UpgradeNodes(t *testing.T, ctx context.Context, chain *cosmos.CosmosChain, client *client.Client, haltHeight uint64, upgradeRepo, upgradeBranchVersion string) {
+	// bring down nodes to prepare for upgrade
+	t.Log("stopping node(s)")
+	err := chain.StopAllNodes(ctx)
+	require.NoError(t, err, "error stopping node(s)")
+
+	// upgrade version on all nodes
+	t.Log("upgrading node(s)")
+	chain.UpgradeVersion(ctx, client, upgradeRepo, upgradeBranchVersion)
+
+	// start all nodes back up.
+	// validators reach consensus on first block after upgrade height
+	// and chain block production resumes.
+	t.Log("starting node(s)")
+	err = chain.StartAllNodes(ctx)
+	require.NoError(t, err, "error starting upgraded node(s)")
+
+	timeoutCtx, timeoutCtxCancel := context.WithTimeout(ctx, time.Second*60)
+	defer timeoutCtxCancel()
+
+	err = testutil.WaitForBlocks(timeoutCtx, int(blocksAfterUpgrade), chain)
+	require.NoError(t, err, "chain did not produce blocks after upgrade")
+
+	height, err := chain.Height(ctx)
+	require.NoError(t, err, "error fetching height after upgrade")
+
+	require.GreaterOrEqual(t, height, haltHeight+blocksAfterUpgrade, "height did not increment enough after upgrade")
+}
+
+func ValidatorVoting(t *testing.T, ctx context.Context, chain *cosmos.CosmosChain, proposalID string, height uint64, haltHeight uint64) {
+	err := chain.VoteOnProposalAllValidators(ctx, proposalID, cosmos.ProposalVoteYes)
 	require.NoError(t, err, "failed to submit votes")
 
-	_, err = cosmos.PollForProposalStatus(ctx, chain, height, height+haltHeightDelta, upgradeTx.ProposalID, cosmos.ProposalStatusPassed)
+	_, err = cosmos.PollForProposalStatus(ctx, chain, height, height+haltHeightDelta, proposalID, cosmos.ProposalStatusPassed)
 	require.NoError(t, err, "proposal status did not change to passed in expected number of blocks")
 
 	timeoutCtx, timeoutCtxCancel := context.WithTimeout(ctx, time.Second*45)
@@ -135,31 +115,27 @@ func CosmosChainUpgradeTest(t *testing.T, chainName, initialVersion, upgradeBran
 
 	// make sure that chain is halted
 	require.Equal(t, haltHeight, height, "height is not equal to halt height")
+}
 
-	// bring down nodes to prepare for upgrade
-	t.Log("stopping node(s)")
-	err = chain.StopAllNodes(ctx)
-	require.NoError(t, err, "error stopping node(s)")
+func SubmitUpgradeProposal(t *testing.T, ctx context.Context, chain *cosmos.CosmosChain, user ibc.Wallet, upgradeName string, haltHeight uint64) string {
+	// TODO Return proposal id
+	upgradeMsg := []cosmosproto.Message{
+		&upgradetypes.MsgSoftwareUpgrade{
+			// gGov Module account
+			Authority: "juno10d07y265gmmuvt4z0w9aw880jnsr700jvss730",
+			Plan: upgradetypes.Plan{
+				Name:   upgradeName,
+				Height: int64(haltHeight),
+			},
+		},
+	}
 
-	// upgrade version on all nodes
-	t.Log("upgrading node(s)")
-	chain.UpgradeVersion(ctx, client, upgradeRepo, upgradeBranchVersion)
+	proposal, err := chain.BuildProposal(upgradeMsg, "Chain Upgrade 1", "Summary desc", "ipfs://CID", fmt.Sprintf(`500000000%s`, chain.Config().Denom))
+	require.NoError(t, err, "error building proposal")
 
-	// start all nodes back up.
-	// validators reach consensus on first block after upgrade height
-	// and chain block production resumes.
-	t.Log("starting node(s)")
-	err = chain.StartAllNodes(ctx)
-	require.NoError(t, err, "error starting upgraded node(s)")
+	txProp, err := chain.SubmitProposal(ctx, user.KeyName(), proposal)
+	t.Log("txProp", txProp)
+	require.NoError(t, err, "error submitting proposal")
 
-	timeoutCtx, timeoutCtxCancel = context.WithTimeout(ctx, time.Second*60)
-	defer timeoutCtxCancel()
-
-	err = testutil.WaitForBlocks(timeoutCtx, int(blocksAfterUpgrade), chain)
-	require.NoError(t, err, "chain did not produce blocks after upgrade")
-
-	height, err = chain.Height(ctx)
-	require.NoError(t, err, "error fetching height after upgrade")
-
-	require.GreaterOrEqual(t, height, haltHeight+blocksAfterUpgrade, "height did not increment enough after upgrade")
+	return txProp.ProposalID
 }

--- a/interchaintest/chain_upgrade_test.go
+++ b/interchaintest/chain_upgrade_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	haltHeightDelta    = uint64(10) // will propose upgrade this many blocks in the future
+	haltHeightDelta    = uint64(9) // will propose upgrade this many blocks in the future
 	blocksAfterUpgrade = uint64(7)
 )
 


### PR DESCRIPTION
## reason
A lot of the code can be abstracted so the test is easier to add new logic checks too & tear down. Overall just cleaner

## description
- abstract away building the chain (with v47 params
- `SubmitUpgradeProposal` builds and submits the new v47 upgrade prop
- `ValidatorVoting` votes and gets prepped for halting
- `UpgradeNodes` upgrades at halted height and restarts nodes