### PR TITLE
fix: Fix pointer to store upgrades inside loop

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -65,7 +65,7 @@ import (
 
 	"github.com/CosmosContracts/juno/v16/app/keepers"
 	"github.com/CosmosContracts/juno/v16/app/openapiconsole"
-	upgrades "github.com/CosmosContracts/juno/v16/app/upgrades"
+	"github.com/CosmosContracts/juno/v16/app/upgrades"
 	v10 "github.com/CosmosContracts/juno/v16/app/upgrades/v10"
 	v11 "github.com/CosmosContracts/juno/v16/app/upgrades/v11"
 	v12 "github.com/CosmosContracts/juno/v16/app/upgrades/v12"
@@ -616,8 +616,9 @@ func (app *App) setupUpgradeStoreLoaders() {
 
 	for _, upgrade := range Upgrades {
 		if upgradeInfo.Name == upgrade.UpgradeName {
+			storeUpgrades := upgrade.StoreUpgrades
 			app.SetStoreLoader(
-				upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &upgrade.StoreUpgrades),
+				upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades),
 			)
 		}
 	}


### PR DESCRIPTION
Due to how `for` loop works, if many upgrade plans are specified, the store upgrades are taken from the last one on the list, not the one matched by the upgrade name. To fix this, the copy of the object is made, before taking the pointer.