### PR TITLE
feat!: More global fee bypasses

### DIFF
--- a/app/ante.go
+++ b/app/ante.go
@@ -26,7 +26,8 @@ import (
 	globalfeekeeper "github.com/CosmosContracts/juno/v17/x/globalfee/keeper"
 )
 
-const maxBypassMinFeeMsgGasUsage = 1_000_000
+// Lower back to 1 mil after https://github.com/cosmos/relayer/issues/1255
+const maxBypassMinFeeMsgGasUsage = 2_000_000
 
 // HandlerOptions extends the SDK's AnteHandler options by requiring the IBC
 // channel keeper and a BankKeeper with an added method for fee sharing.

--- a/app/app.go
+++ b/app/app.go
@@ -481,6 +481,9 @@ func GetDefaultBypassFeeMessages() []string {
 		sdk.MsgTypeURL(&ibctransfertypes.MsgTransfer{}),
 		sdk.MsgTypeURL(&ibcchanneltypes.MsgTimeout{}),
 		sdk.MsgTypeURL(&ibcchanneltypes.MsgTimeoutOnClose{}),
+		sdk.MsgTypeURL(&ibcchanneltypes.MsgChannelOpenTry{}),
+		sdk.MsgTypeURL(&ibcchanneltypes.MsgChannelOpenConfirm{}),
+		sdk.MsgTypeURL(&ibcchanneltypes.MsgChannelOpenAck{}),
 	}
 }
 


### PR DESCRIPTION
## Summary
Due to usage of TFM & PFM + IBCHooks, IBC packets are much larger than the past. With this, more complex transfers are costing more and validators are not pushing through the packets except when done manually with fees.

## Solution
- Increase gas limit from 1m to 2m temporarily 
- [Add MsgChannelOpen* messages to bypass per relayer request](https://discord.com/channels/816256689078403103/876537608438710382/1140938140350152755)
