### PR TITLE
ictest: cache deps on setup, cache Docker Image layers

### DIFF
--- a/.github/workflows/interchaintest-E2E.yml
+++ b/.github/workflows/interchaintest-E2E.yml
@@ -33,7 +33,11 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: interchaintest/go.sum
+          cache-dependency-path: "**/go.sum"
+          cache: true
+
+      - name: Download Go Deps
+        run: make download-deps
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -43,6 +47,8 @@ jobs:
         with:
           context: .
           tags: juno:local
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           outputs: type=docker,dest=${{ env.TAR_PATH }}
 
       - name: Upload artifact
@@ -76,7 +82,8 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: interchaintest/go.sum
+          cache-dependency-path: "**/go.sum"
+          cache: true          
 
       - name: checkout chain
         uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,11 @@ build:
 test-node:
 	CHAIN_ID="local-1" HOME_DIR="~/.juno1" TIMEOUT_COMMIT="500ms" CLEAN=true sh scripts/test_node.sh
 
+download-deps:
+	@echo "--> caching go deps"
+	@go mod download
+	@cd interchaintest && go mod download
+
 ###############################################################################
 ###                                Testing                                  ###
 ###############################################################################


### PR DESCRIPTION
Closes #790

Get other references from repos such as the tokenfactory-contracts and other e2e external repos