### PR TITLE
fix!: RegisterMsgServer for x/GlobalFee

### DIFF
--- a/x/globalfee/module.go
+++ b/x/globalfee/module.go
@@ -131,6 +131,7 @@ func (a AppModule) QuerierRoute() string {
 }
 
 func (a AppModule) RegisterServices(cfg module.Configurator) {
+	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(a.keeper))
 	types.RegisterQueryServer(cfg.QueryServer(), NewGrpcQuerier(a.keeper))
 
 	m := keeper.NewMigrator(a.keeper, a.bondDenom)

--- a/x/globalfee/types/codec.go
+++ b/x/globalfee/types/codec.go
@@ -8,6 +8,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
 	authzcodec "github.com/cosmos/cosmos-sdk/x/authz/codec"
+	govcodec "github.com/cosmos/cosmos-sdk/x/gov/codec"
 )
 
 var (
@@ -24,6 +25,7 @@ func init() {
 	// so that this can later be used to properly serialize MsgGrant and MsgExec
 	// instances.
 	RegisterLegacyAminoCodec(authzcodec.Amino)
+	RegisterLegacyAminoCodec(govcodec.Amino)
 }
 
 // RegisterLegacyAminoCodec registers concrete types on the LegacyAmino codec


### PR DESCRIPTION
I missed this in the v16 upgrade oops :( - Adds so Gov can actually UpdateParams (Found thanks to setting up the x/clock module)

I need to write e2e test for all UpdateParams to confirm our custom messages work, not just the MsgServer