### PR TITLE
Prettier GlobalFee fees errors

### DIFF
--- a/x/globalfee/ante/fee.go
+++ b/x/globalfee/ante/fee.go
@@ -1,6 +1,7 @@
 package ante
 
 import (
+	"encoding/json"
 	"errors"
 
 	tmstrings "github.com/cometbft/cometbft/libs/strings"
@@ -125,11 +126,20 @@ func (mfd FeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, ne
 		// because when nonZeroCoinFeesReq empty, and DenomsSubsetOf check passed,
 		// the tx should already passed before)
 		if !feeCoinsNonZeroDenom.IsAnyGTE(nonZeroCoinFeesReq) {
-			return ctx, errorsmod.Wrapf(sdkerrors.ErrInsufficientFee, "insufficient fees; got: %s required: %s", feeCoins, combinedFeeRequirement)
+			return ctx, errorsmod.Wrapf(sdkerrors.ErrInsufficientFee, "insufficient fees; got: %s. required: %s", feeCoins, PrettyPrint(combinedFeeRequirement))
 		}
 	}
 
 	return next(ctx, tx, simulate)
+}
+
+func PrettyPrint(v interface{}) string {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return ""
+	}
+
+	return string(b)
 }
 
 // GetGlobalFee returns the global fees for a given fee tx's gas

--- a/x/globalfee/ante/fee.go
+++ b/x/globalfee/ante/fee.go
@@ -126,7 +126,11 @@ func (mfd FeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, ne
 		// because when nonZeroCoinFeesReq empty, and DenomsSubsetOf check passed,
 		// the tx should already passed before)
 		if !feeCoinsNonZeroDenom.IsAnyGTE(nonZeroCoinFeesReq) {
-			return ctx, errorsmod.Wrapf(sdkerrors.ErrInsufficientFee, "insufficient fees; got: %s. required: %s", feeCoins, PrettyPrint(combinedFeeRequirement))
+			if len(feeCoins) == 0 {
+				return ctx, errorsmod.Wrapf(sdkerrors.ErrInsufficientFee, "no fees were specified. fees must be provided in one of %s", PrettyPrint(combinedFeeRequirement))
+			}
+
+			return ctx, errorsmod.Wrapf(sdkerrors.ErrInsufficientFee, "insufficient fees; only got: %s. required: %s", feeCoins, PrettyPrint(combinedFeeRequirement))
 		}
 	}
 

--- a/x/globalfee/ante/fee.go
+++ b/x/globalfee/ante/fee.go
@@ -89,7 +89,7 @@ func (mfd FeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, ne
 	// if feeCoinsNoZeroDenom=[], DenomsSubsetOf returns true
 	// if feeCoinsNoZeroDenom is not empty, but nonZeroCoinFeesReq empty, return false
 	if !feeCoinsNonZeroDenom.DenomsSubsetOf(nonZeroCoinFeesReq) {
-		return ctx, errorsmod.Wrapf(sdkerrors.ErrInsufficientFee, "fee is not a subset of required fees; got %s, required: %s", feeCoins, combinedFeeRequirement)
+		return ctx, errorsmod.Wrapf(sdkerrors.ErrInsufficientFee, "this fee denom is not accepted; got %s, required: %s", feeCoins, PrettyPrint(combinedFeeRequirement))
 	}
 
 	// Accept zero fee transactions only if both of the following statements are true:

--- a/x/globalfee/ante/fee_utils.go
+++ b/x/globalfee/ante/fee_utils.go
@@ -1,6 +1,9 @@
 package ante
 
 import (
+	"encoding/json"
+	"fmt"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -17,6 +20,21 @@ func ContainZeroCoins(coins sdk.Coins) bool {
 	}
 
 	return false
+}
+
+// PrettyPrint returns a pretty printed representation of the given coins.
+func PrettyPrint(coins sdk.Coins) string {
+	arr := make([]string, len(coins))
+	for idx, coin := range coins {
+		arr[idx] = fmt.Sprintf("%s%s", coin.Amount.String(), coin.Denom)
+	}
+
+	bz, err := json.MarshalIndent(arr, "", "  ")
+	if err != nil {
+		return ""
+	}
+
+	return string(bz)
 }
 
 // CombinedFeeRequirement returns the global fee and min_gas_price combined and sorted.


### PR DESCRIPTION
I have seen a lot of developers confused by the CLI fee message (all of cosmos, not just Juno). This makes it prettier so it's easier to understand

---

not enough
![image](https://github.com/CosmosContracts/juno/assets/31943163/30f8a4c4-9a49-41cc-a50b-3f065776a17e)

not accepted
![image](https://github.com/CosmosContracts/juno/assets/31943163/98c00b82-a737-4eed-af7b-e1ac63aec404)


none input at all but one is required
![image](https://github.com/CosmosContracts/juno/assets/31943163/4f6db7e9-4fd6-4399-94e6-aa5df4d8f3b7)

