### PR TITLE
reduce tokens in targetsupply when burning

### DIFF
--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -525,7 +525,7 @@ func NewAppKeepers(
 	// 	return wasmkeeper.NewBurnCoinMessageHandler(customBurner)
 	// })
 
-	junoBurnerPlugin := junoburn.NewBurnerPlugin(appKeepers.BankKeeper)
+	junoBurnerPlugin := junoburn.NewBurnerPlugin(appKeepers.BankKeeper, appKeepers.MintKeeper)
 	burnOverride := wasmkeeper.WithMessageHandler(wasmkeeper.NewBurnCoinMessageHandler(junoBurnerPlugin))
 	wasmOpts = append(wasmOpts, burnOverride)
 

--- a/x/burn/burner.go
+++ b/x/burn/burner.go
@@ -3,9 +3,10 @@ package burn
 import (
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 
-	mintkeeper "github.com/CosmosContracts/juno/v17/x/mint/keeper"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
+
+	mintkeeper "github.com/CosmosContracts/juno/v17/x/mint/keeper"
 )
 
 // used to override Wasmd's NewBurnCoinMessageHandler
@@ -33,10 +34,11 @@ func (k *BurnerWasmPlugin) BurnCoins(ctx sdk.Context, moduleName string, amt sdk
 
 	// loop the burned coins
 	for _, amount := range amt {
-
 		// if we are burning mint denom, reduce the target staking supply
 		if amount.Denom == params.MintDenom {
-			k.mk.ReduceTargetSupply(ctx, amount)
+			if err := k.mk.ReduceTargetSupply(ctx, amount); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/x/burn/burner.go
+++ b/x/burn/burner.go
@@ -3,6 +3,7 @@ package burn
 import (
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 
+	mintkeeper "github.com/CosmosContracts/juno/v17/x/mint/keeper"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
 )
@@ -11,17 +12,34 @@ import (
 
 type BurnerWasmPlugin struct {
 	bk bankkeeper.Keeper
+	mk mintkeeper.Keeper
 }
 
 var _ wasmtypes.Burner = &BurnerWasmPlugin{}
 
-func NewBurnerPlugin(bk bankkeeper.Keeper) *BurnerWasmPlugin {
-	return &BurnerWasmPlugin{bk: bk}
+func NewBurnerPlugin(bk bankkeeper.Keeper, mk mintkeeper.Keeper) *BurnerWasmPlugin {
+	return &BurnerWasmPlugin{bk: bk, mk: mk}
 }
 
-func (k *BurnerWasmPlugin) BurnCoins(_ sdk.Context, _ string, _ sdk.Coins) error {
-	// instead of burning, we just hold in balance and subtract from the x/mint module's total supply
-	// return k.bk.BurnCoins(ctx, moduleName, amt)
+func (k *BurnerWasmPlugin) BurnCoins(ctx sdk.Context, moduleName string, amt sdk.Coins) error {
+	// first, try to burn the coins on bank module
+	err := k.bk.BurnCoins(ctx, moduleName, amt)
+	if err != nil {
+		return err
+	}
+
+	// get mint params
+	params := k.mk.GetParams(ctx)
+
+	// loop the burned coins
+	for _, amount := range amt {
+
+		// if we are burning mint denom, reduce the target staking supply
+		if amount.Denom == params.MintDenom {
+			k.mk.ReduceTargetSupply(ctx, amount)
+		}
+	}
+
 	return nil
 }
 

--- a/x/mint/keeper/keeper.go
+++ b/x/mint/keeper/keeper.go
@@ -157,7 +157,7 @@ func (k Keeper) ReduceTargetSupply(ctx sdk.Context, burnCoin sdk.Coin) error {
 	params := k.GetParams(ctx)
 
 	if burnCoin.Denom != params.MintDenom {
-		return fmt.Errorf("Tried reducing target supply with non staking token")
+		return fmt.Errorf("tried reducing target supply with non staking token")
 	}
 
 	minter := k.GetMinter(ctx)

--- a/x/mint/keeper/keeper.go
+++ b/x/mint/keeper/keeper.go
@@ -153,6 +153,20 @@ func (k Keeper) MintCoins(ctx sdk.Context, newCoins sdk.Coins) error {
 	return k.bankKeeper.MintCoins(ctx, types.ModuleName, newCoins)
 }
 
+func (k Keeper) ReduceTargetSupply(ctx sdk.Context, burnCoin sdk.Coin) error {
+	params := k.GetParams(ctx)
+
+	if burnCoin.Denom != params.MintDenom {
+		return fmt.Errorf("Tried reducing target supply with non staking token")
+	}
+
+	minter := k.GetMinter(ctx)
+	minter.TargetSupply = minter.TargetSupply.Sub(burnCoin.Amount)
+	k.SetMinter(ctx, minter)
+
+	return nil
+}
+
 // AddCollectedFees implements an alias call to the underlying supply keeper's
 // AddCollectedFees to be used in BeginBlocker.
 func (k Keeper) AddCollectedFees(ctx sdk.Context, fees sdk.Coins) error {

--- a/x/mint/simulation/genesis_test.go
+++ b/x/mint/simulation/genesis_test.go
@@ -76,7 +76,8 @@ func TestRandomizedGenState1(t *testing.T) {
 			}, "assignment to entry in nil map"},
 	}
 
-	for _, tt := range tests {
-		require.Panicsf(t, func() { simulation.RandomizedGenState(&tt.simState) }, tt.panicMsg)
+	for _, tc := range tests {
+		tc := tc
+		require.Panicsf(t, func() { simulation.RandomizedGenState(&tc.simState) }, tc.panicMsg)
 	}
 }

--- a/x/tokenfactory/keeper/admins_test.go
+++ b/x/tokenfactory/keeper/admins_test.go
@@ -131,6 +131,7 @@ func (suite *KeeperTestSuite) TestMintDenom() {
 		},
 	} {
 		suite.Run(fmt.Sprintf("Case %s", tc.desc), func() {
+			tc := tc
 			_, err := suite.msgServer.Mint(sdk.WrapSDKContext(suite.Ctx), &tc.mintMsg)
 			if tc.expectPass {
 				suite.Require().NoError(err)
@@ -207,6 +208,7 @@ func (suite *KeeperTestSuite) TestBurnDenom() {
 		},
 	} {
 		suite.Run(fmt.Sprintf("Case %s", tc.desc), func() {
+			tc := tc
 			_, err := suite.msgServer.Burn(sdk.WrapSDKContext(suite.Ctx), &tc.burnMsg)
 			if tc.expectPass {
 				suite.Require().NoError(err)
@@ -281,6 +283,7 @@ func (suite *KeeperTestSuite) TestForceTransferDenom() {
 		},
 	} {
 		suite.Run(fmt.Sprintf("Case %s", tc.desc), func() {
+			tc := tc
 			_, err := suite.msgServer.ForceTransfer(sdk.WrapSDKContext(suite.Ctx), &tc.forceTransferMsg)
 			if tc.expectPass {
 				suite.Require().NoError(err)
@@ -506,6 +509,7 @@ func (suite *KeeperTestSuite) TestSetDenomMetaData() {
 	} {
 		suite.Run(fmt.Sprintf("Case %s", tc.desc), func() {
 			bankKeeper := suite.App.AppKeepers.BankKeeper
+			tc := tc
 			res, err := suite.msgServer.SetDenomMetadata(sdk.WrapSDKContext(suite.Ctx), &tc.msgSetDenomMetadata)
 			if tc.expectedPass {
 				suite.Require().NoError(err)

--- a/x/tokenfactory/keeper/msg_server_test.go
+++ b/x/tokenfactory/keeper/msg_server_test.go
@@ -238,6 +238,7 @@ func (suite *KeeperTestSuite) TestSetDenomMetaDataMsg() {
 		},
 	} {
 		suite.Run(fmt.Sprintf("Case %s", tc.desc), func() {
+			tc := tc
 			ctx := suite.Ctx.WithEventManager(sdk.NewEventManager())
 			suite.Require().Equal(0, len(ctx.EventManager().Events()))
 			// Test set denom metadata message


### PR DESCRIPTION
this pr is targeting reece branch


- This way the bank.totalSupply will always be right
- By reducing target supply, we reduce also the maxSupply and we shorten the halving date

maxSupply is actually reduced way more than the burned coins, because maxsupply is calculated dynamically at each 1 year epoch based on inflation schedule

this table estimates how much the max supply will be impacted for a burn in each phase schedule

|  Year | Burn Amount   | Effective Max Supply reduction   |
|---|---|---|
|  2 | 1 JUNO | 2.04 JUNO  |   
| 3  | 1 JUNO |  1.70 JUNO |   
| 4  | 1 JUNO |  1.54 JUNO |
| 5 | 1 JUNO | 1.41 JUNO |
| 6 | 1 JUNO | 1.31 JUNO |
| 7 | 1 JUNO | 1.22 JUNO | 
| 8 | 1 JUNO | 1.15 JUNO |
| 9 | 1 JUNO | 1.10 JUNO |
| 10 | 1 JUNO | 1.06 JUNO | 
| 11 | 1 JUNO | 1.03 JUNO |
| 12 | 1 JUNO | 1.00 JUNO |