### PR TITLE
chore: updating discord link in RELEASES.md

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,7 +4,7 @@ The `#validators-private` channel on discord will be used for all communications
 
 **The core team will endeavor to always make sure there is 48-72 hours notice of an impending upgrade unless there is no alternative.**
 
-Most of our validator communications are done on the [Juno Discord](https://discord.gg/Juno). You should join, and change your server name to `nick | validator-name`, then ask a mod for permission to see the private validator channels.
+Most of our validator communications are done on the [Juno Discord](https://discord.gg/wHdzjS5vXx). You should join, and change your server name to `nick | validator-name`, then ask a mod for permission to see the private validator channels.
 
 ## Release versioning
 


### PR DESCRIPTION
Hi, reading the doc I found out a current discord link is down, so I figured I would correct it myself instead of opening an issue and requiring someone to open a PR.

I found out the new discord link in readme.md, so it should be permanent. All other discord links are working in the repo.

That's it, doesn't require testing or changelog entry.