### PR TITLE
fix(upgrade): clock params

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -70,6 +70,7 @@ import (
 	testnetV18alpha2 "github.com/CosmosContracts/juno/v19/app/upgrades/testnet/v18.0.0-alpha.2"
 	testnetV18alpha3 "github.com/CosmosContracts/juno/v19/app/upgrades/testnet/v18.0.0-alpha.3"
 	testnetV18alpha4 "github.com/CosmosContracts/juno/v19/app/upgrades/testnet/v18.0.0-alpha.4"
+	testnetV19alpha2 "github.com/CosmosContracts/juno/v19/app/upgrades/testnet/v19.0.0-alpha.2"
 	v10 "github.com/CosmosContracts/juno/v19/app/upgrades/v10"
 	v11 "github.com/CosmosContracts/juno/v19/app/upgrades/v11"
 	v12 "github.com/CosmosContracts/juno/v19/app/upgrades/v12"
@@ -106,6 +107,7 @@ var (
 		testnetV18alpha2.Upgrade,
 		testnetV18alpha3.Upgrade,
 		testnetV18alpha4.Upgrade,
+		testnetV19alpha2.Upgrade,
 
 		v10.Upgrade,
 		v11.Upgrade,

--- a/app/upgrades/testnet/v19.0.0-alpha.2/constants.go
+++ b/app/upgrades/testnet/v19.0.0-alpha.2/constants.go
@@ -1,0 +1,48 @@
+package v18
+
+import (
+	"fmt"
+
+	store "github.com/cosmos/cosmos-sdk/store/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+
+	"github.com/CosmosContracts/juno/v19/app/keepers"
+	"github.com/CosmosContracts/juno/v19/app/upgrades"
+	clocktypes "github.com/CosmosContracts/juno/v19/x/clock/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+)
+
+// UpgradeName defines the on-chain upgrade name for the upgrade.
+const UpgradeName = "v1900alpha2"
+
+var Upgrade = upgrades.Upgrade{
+	UpgradeName:          UpgradeName,
+	CreateUpgradeHandler: v1900Alpha2UpgradeHandler,
+	StoreUpgrades:        store.StoreUpgrades{},
+}
+
+func v1900Alpha2UpgradeHandler(
+	mm *module.Manager,
+	cfg module.Configurator,
+	k *keepers.AppKeepers,
+) upgradetypes.UpgradeHandler {
+	return func(ctx sdk.Context, _ upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+		logger := ctx.Logger().With("upgrade", UpgradeName)
+
+		logger.Info(fmt.Sprintf("pre migrate version map: %v", vm))
+		versionMap, err := mm.RunMigrations(ctx, cfg, vm)
+		if err != nil {
+			return nil, err
+		}
+		logger.Info(fmt.Sprintf("post migrate version map: %v", versionMap))
+
+		if err := k.ClockKeeper.SetParams(ctx, clocktypes.Params{
+			ContractGasLimit: 250_000,
+		}); err != nil {
+			return nil, err
+		}
+
+		return versionMap, nil
+	}
+}

--- a/app/upgrades/testnet/v19.0.0-alpha.2/constants.go
+++ b/app/upgrades/testnet/v19.0.0-alpha.2/constants.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 
 	store "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
 	"github.com/CosmosContracts/juno/v19/app/keepers"
 	"github.com/CosmosContracts/juno/v19/app/upgrades"
 	clocktypes "github.com/CosmosContracts/juno/v19/x/clock/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 )
 
 // UpgradeName defines the on-chain upgrade name for the upgrade.

--- a/app/upgrades/testnet/v19.0.0-alpha.2/upgrade_test.go
+++ b/app/upgrades/testnet/v19.0.0-alpha.2/upgrade_test.go
@@ -1,0 +1,40 @@
+package v18_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/CosmosContracts/juno/v19/app/apptesting"
+	v19alpha2 "github.com/CosmosContracts/juno/v19/app/upgrades/testnet/v19.0.0-alpha.2"
+)
+
+type UpgradeTestSuite struct {
+	apptesting.KeeperTestHelper
+}
+
+func (s *UpgradeTestSuite) SetupTest() {
+	s.Setup()
+}
+
+func TestKeeperTestSuite(t *testing.T) {
+	suite.Run(t, new(UpgradeTestSuite))
+}
+
+// Ensures the test does not error out.
+func (s *UpgradeTestSuite) TestUpgrade() {
+	s.Setup()
+
+	preUpgradeChecks(s)
+
+	upgradeHeight := int64(5)
+	s.ConfirmUpgradeSucceeded(v19alpha2.UpgradeName, upgradeHeight)
+
+	postUpgradeChecks(s)
+}
+
+func preUpgradeChecks(_ *UpgradeTestSuite) {
+}
+
+func postUpgradeChecks(_ *UpgradeTestSuite) {
+}

--- a/app/upgrades/v19/upgrades.go
+++ b/app/upgrades/v19/upgrades.go
@@ -16,6 +16,7 @@ import (
 	decorators "github.com/CosmosContracts/juno/v19/app/decorators"
 	"github.com/CosmosContracts/juno/v19/app/keepers"
 	"github.com/CosmosContracts/juno/v19/app/upgrades"
+	clocktypes "github.com/CosmosContracts/juno/v19/x/clock/types"
 )
 
 func CreateV19UpgradeHandler(
@@ -57,6 +58,12 @@ func CreateV19UpgradeHandler(
 		params := k.IBCKeeper.ClientKeeper.GetParams(ctx)
 		params.AllowedClients = append(params.AllowedClients, wasmlctypes.Wasm)
 		k.IBCKeeper.ClientKeeper.SetParams(ctx, params)
+
+		if err := k.ClockKeeper.SetParams(ctx, clocktypes.Params{
+			ContractGasLimit: 250_000,
+		}); err != nil {
+			return nil, err
+		}
 
 		return versionMap, err
 	}


### PR DESCRIPTION
Forgot to put clock params in the upgrade handler

testnet: v1900alpha2 upgrade
mainnet: backported same change from `v1900alpha2`

Will go live on testnet next week, confirm clock is good, then mainnet