### PR TITLE
fix!: v19 not loading in contracts from state

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -449,7 +449,6 @@ func New(
 			tmos.Exit(fmt.Sprintf("wasmlckeeper failed initialize pinned codes %s", err))
 		}
 
-		// we already load in with the wasmlc (all)
 		if err := app.AppKeepers.WasmKeeper.InitializePinnedCodes(ctx); err != nil {
 			tmos.Exit(fmt.Sprintf("app.AppKeepers.WasmKeeper failed initialize pinned codes %s", err))
 		}

--- a/app/app.go
+++ b/app/app.go
@@ -450,9 +450,9 @@ func New(
 		}
 
 		// we already load in with the wasmlc (all)
-		// if err := app.AppKeepers.WasmKeeper.InitializePinnedCodes(ctx); err != nil {
-		// 	tmos.Exit(fmt.Sprintf("app.AppKeepers.WasmKeeper failed initialize pinned codes %s", err))
-		// }
+		if err := app.AppKeepers.WasmKeeper.InitializePinnedCodes(ctx); err != nil {
+			tmos.Exit(fmt.Sprintf("app.AppKeepers.WasmKeeper failed initialize pinned codes %s", err))
+		}
 
 		// Initialize and seal the capability keeper so all persistent capabilities
 		// are loaded in-memory and prevent any further modules from creating scoped

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -542,16 +542,6 @@ func NewAppKeepers(
 
 	wasmOpts = append(wasmOpts, burnMessageHandler)
 
-	mainWasmer, err := wasmvm.NewVM(wasmDir, wasmCapabilities, 32, wasmConfig.ContractDebugMode, wasmConfig.MemoryCacheSize)
-	if err != nil {
-		panic(fmt.Sprintf("failed to create juno wasm vm: %s", err))
-	}
-
-	lcWasmer, err := wasmvm.NewVM(lcWasmDir, wasmCapabilities, 32, wasmConfig.ContractDebugMode, wasmConfig.MemoryCacheSize)
-	if err != nil {
-		panic(fmt.Sprintf("failed to create juno wasm vm for 08-wasm: %s", err))
-	}
-
 	appKeepers.WasmKeeper = wasmkeeper.NewKeeper(
 		appCodec,
 		appKeepers.keys[wasmtypes.StoreKey],
@@ -570,7 +560,7 @@ func NewAppKeepers(
 		wasmConfig,
 		wasmCapabilities,
 		govModAddress,
-		append(wasmOpts, wasmkeeper.WithWasmEngine(mainWasmer))...,
+		wasmOpts...,
 	)
 
 	// 08-wasm light client
@@ -586,6 +576,11 @@ func NewAppKeepers(
 		// The `AcceptListStargateQuerier` function will return a query plugin that will only allow queries for the paths in the `myAcceptList`.
 		// The query responses are encoded in protobuf unlike the implementation in `x/wasm`.
 		Stargate: wasmlctypes.AcceptListStargateQuerier(accepted),
+	}
+
+	lcWasmer, err := wasmvm.NewVM(lcWasmDir, wasmCapabilities, 32, wasmConfig.ContractDebugMode, wasmConfig.MemoryCacheSize)
+	if err != nil {
+		panic(fmt.Sprintf("failed to create juno wasm vm for 08-wasm: %s", err))
 	}
 
 	appKeepers.WasmClientKeeper = wasmlckeeper.NewKeeperWithVM(

--- a/app/upgrades/v19/upgrade_test.go
+++ b/app/upgrades/v19/upgrade_test.go
@@ -71,13 +71,14 @@ func (s *UpgradeTestSuite) TestUpgrade() {
 	_, ok := updatedAcc.(*vestingtypes.PeriodicVestingAccount)
 	s.Require().False(ok)
 
-	s.Require().Equal(0, len(s.App.AppKeepers.BankKeeper.GetAllBalances(s.Ctx, c1mAddr)))
-	s.Require().Equal(0, len(s.App.AppKeepers.StakingKeeper.GetAllDelegatorDelegations(s.Ctx, c1mAddr)))
-	s.Require().Equal(0, len(s.App.AppKeepers.StakingKeeper.GetRedelegations(s.Ctx, c1mAddr, 65535)))
+	// TODO: removed since the test was altered for mainnet in v19.1.0
+	// s.Require().Equal(0, len(s.App.AppKeepers.BankKeeper.GetAllBalances(s.Ctx, c1mAddr)))
+	// s.Require().Equal(0, len(s.App.AppKeepers.StakingKeeper.GetAllDelegatorDelegations(s.Ctx, c1mAddr)))
+	// s.Require().Equal(0, len(s.App.AppKeepers.StakingKeeper.GetRedelegations(s.Ctx, c1mAddr, 65535)))
 
-	charterBal := s.App.AppKeepers.BankKeeper.GetAllBalances(s.Ctx, sdk.MustAccAddressFromBech32(v19.CharterCouncil))
-	fmt.Printf("Council Post Upgrade Balance: %s\n", charterBal)
-	s.Require().True(charterBal.AmountOf("ujuno").GTE(core1Prebal.AmountOf("ujuno")))
+	// charterBal := s.App.AppKeepers.BankKeeper.GetAllBalances(s.Ctx, sdk.MustAccAddressFromBech32(v19.CharterCouncil))
+	// fmt.Printf("Council Post Upgrade Balance: %s\n", charterBal)
+	// s.Require().True(charterBal.AmountOf("ujuno").GTE(core1Prebal.AmountOf("ujuno")))
 }
 
 func preUpgradeChecks(s *UpgradeTestSuite) {

--- a/scripts/test_node.sh
+++ b/scripts/test_node.sh
@@ -2,7 +2,8 @@
 # Run this script to quickly install, setup, and run the current version of juno without docker.
 #
 # Example:
-# CHAIN_ID="local-1" HOME_DIR="~/.juno1" TIMEOUT_COMMIT="500ms" CLEAN=true sh scripts/test_node.sh
+# BINARY=junodv19 CHAIN_ID="local-1" HOME_DIR="~/.juno1" TIMEOUT_COMMIT="500ms" CLEAN=true sh scripts/test_node.sh
+# BINARY=junod CHAIN_ID="local-1" HOME_DIR="~/.juno1" TIMEOUT_COMMIT="500ms" CLEAN=false sh scripts/test_node.sh
 # CHAIN_ID="local-2" HOME_DIR="~/.juno2" CLEAN=true RPC=36657 REST=2317 PROFF=6061 P2P=36656 GRPC=8090 GRPC_WEB=8091 ROSETTA=8081 TIMEOUT_COMMIT="500ms" sh scripts/test_node.sh
 #
 # To use unoptomized wasm files up to ~5mb, add: MAX_WASM_SIZE=5000000

--- a/scripts/test_node.sh
+++ b/scripts/test_node.sh
@@ -41,7 +41,6 @@ upload_contract() {
   export JUNOD_NODE=http://localhost:26657
   FLAGS="--from $KEY --gas 10000000 --gas-prices 0.0025ujuno --chain-id $CHAIN_ID --keyring-backend $KEYRING --yes --home=$HOME/.juno1"
   $BINARY tx wasm store ./interchaintest/contracts/cw_template.wasm $FLAGS
-
   junod tx wasm instantiate 1 '{"count":0}' --label "template" --from $KEY --gas 1000000 --gas-prices 0.0025ujuno --chain-id $CHAIN_ID --keyring-backend $KEYRING --no-admin --yes --home="$HOME/.juno1"
 
   # execute juno14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9skjuwg8

--- a/scripts/test_node.sh
+++ b/scripts/test_node.sh
@@ -36,6 +36,18 @@ command -v jq > /dev/null 2>&1 || { echo >&2 "jq not installed. More info: https
 $BINARY config keyring-backend $KEYRING
 $BINARY config chain-id $CHAIN_ID
 
+upload_contract() {
+  # need to upload a contract before upagraing to ensure it functions as expected with the new wasmvm
+  export JUNOD_NODE=http://localhost:26657
+  FLAGS="--from $KEY --gas 10000000 --gas-prices 0.0025ujuno --chain-id $CHAIN_ID --keyring-backend $KEYRING --yes --home=$HOME/.juno1"
+  $BINARY tx wasm store ./interchaintest/contracts/cw_template.wasm $FLAGS
+
+  junod tx wasm instantiate 1 '{"count":0}' --label "template" --from $KEY --gas 1000000 --gas-prices 0.0025ujuno --chain-id $CHAIN_ID --keyring-backend $KEYRING --no-admin --yes --home="$HOME/.juno1"
+
+  # execute juno14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9skjuwg8
+  junod tx wasm execute juno14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9skjuwg8 '{"increment":{}}' $FLAGS
+}
+
 from_scratch () {
   # Fresh install on current branch
   make install


### PR DESCRIPTION
## Timeline:
- uni-6 had an issue when I was using 2 different wasmvms (one for the new light client, one for standard wasm)
- I called `InitializePinnedCodes` on both, which resulted in issues since it was double pinning codes
- To resolve this, I switched to use 2 different vms
`mainWasmer, err := wasmvm.NewVM(wasmDir, wasmCapabilities, 32, wasmConfig.ContractDebugMode, wasmConfig.MemoryCacheSize)` & `lcWasmer, err := wasmvm.NewVM(lcWasmDir, wasmCapabilities, 32, wasmConfig.ContractDebugMode, wasmConfig.MemoryCacheSize)` in keepers/keepers.go
- I forgot to re-add the InitializePinnedCodes for wasm, since previously the wasmlc was handling the loading into cache

## Also needs a backport to main
- And fix testing