### PR TITLE
ci: allow flaky interchaintest to rerun.

### DIFF
--- a/.github/workflows/interchaintest-E2E.yml
+++ b/.github/workflows/interchaintest-E2E.yml
@@ -99,4 +99,19 @@ jobs:
           docker image ls -a
 
       - name: Run Test
+        id: run_test
+        continue-on-error: true
         run: make ${{ matrix.test }}
+
+      - name: Retry Failed Test
+        if: steps.run_test.outcome == 'failure'
+        run: |
+          for i in 1 2; do
+            echo "Retry attempt $i"
+            if make ${{ matrix.test }}; then
+              echo "Test passed on retry"
+              exit 0
+            fi
+          done
+          echo "Test failed after retries"
+          exit 1


### PR DESCRIPTION
## Description

Update Github actions to attempt failed interchaintest tests for max 2 times so that CI pass in case of flakiness.