### PR TITLE
Fix release-binary action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4
         
       - name: Docker compose
-        run: STAKE_TOKEN="ujunox" TIMEOUT_COMMIT=500ms docker-compose up -d
+        run: STAKE_TOKEN="ujunox" TIMEOUT_COMMIT=500ms docker compose up -d
 
       - name: Copy binary
         run: docker cp juno_node_1:/usr/bin/junod ./junod


### PR DESCRIPTION
`docker-compose` was removed. 

https://github.blog/changelog/2024-04-10-github-hosted-runner-images-deprecation-notice-docker-compose-v1/
![image](https://github.com/user-attachments/assets/2c734322-5f60-4362-a83c-86ed6f334d2e)
