### PR TITLE
Add kintsugi collaborator to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # CODEOWNERS: https://help.github.com/articles/about-codeowners/
 
-* @JakeHartnell @dimiandre
+* @JakeHartnell @dimiandre @niilptr


### PR DESCRIPTION
Add kintsugi validator collaborator to codeowners, to streamline development on juno