### PR TITLE
Fix typos in `cosmwasm.go`, `openapi.yml`, and `swagger.yaml`

### DIFF
--- a/docs/static/openapi.yml
+++ b/docs/static/openapi.yml
@@ -5701,7 +5701,7 @@ paths:
                 type: object
                 properties:
                   commission:
-                    description: commission defines the commision the validator received.
+                    description: commission defines the commission the validator received.
                     type: object
                     properties:
                       commission:
@@ -20163,7 +20163,7 @@ components:
       type: object
       properties:
         commission:
-          description: commission defines the commision the validator received.
+          description: commission defines the commission the validator received.
           type: object
           properties:
             commission:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -5811,7 +5811,7 @@ paths:
             type: object
             properties:
               commission:
-                description: commission defines the commision the validator received.
+                description: commission defines the commission the validator received.
                 type: object
                 properties:
                   commission:
@@ -20639,7 +20639,7 @@ definitions:
     type: object
     properties:
       commission:
-        description: commission defines the commision the validator received.
+        description: commission defines the commission the validator received.
         type: object
         properties:
           commission:

--- a/interchaintest/conformance/cosmwasm.go
+++ b/interchaintest/conformance/cosmwasm.go
@@ -43,7 +43,7 @@ func subMsg(t *testing.T, ctx context.Context, chain *cosmos.CosmosChain, user i
 	fmt.Println("First", res)
 	require.NoError(t, err)
 
-	// this purposely will fail with the current, we are just validating the messsage is not unknown.
+	// this purposely will fail with the current, we are just validating the message is not unknown.
 	// sub message of unknown means the `wasmkeeper.WithMessageHandlerDecorator` is not setup properly.
 	fail := "ImZhaWwi"
 	res2, err := helpers.ExecuteMsgWithFeeReturn(t, ctx, chain, user, senderContractAddr, "", "10000"+chain.Config().Denom, fmt.Sprintf(`{"send_nft": { "contract": "%s", "token_id": "00000", "msg": "%s" }}`, receiverContractAddr, fail))


### PR DESCRIPTION
1. **`openapi.yml` & `swagger.yaml`**:
   - Fixed `commision` → `commission` in descriptions related to validator commission.

2. **`cosmwasm.go`**:
   - Corrected `messsage` → `message` in a comment about validation errors.
