### PR TITLE
fix(x/drip): eliminate duplicate AccAddressFromBech32 call and fix re…

### DIFF
--- a/x/drip/keeper/msg_server.go
+++ b/x/drip/keeper/msg_server.go
@@ -38,8 +38,9 @@ func (ms msgServer) DistributeTokens(
 		return nil, errors.New("sender address cannot be empty")
 	}
 
-	if _, err := sdk.AccAddressFromBech32(msg.SenderAddress); err != nil {
-		return nil, errorsmod.Wrapf(err, "invalid sender address: %s", err.Error())
+	sender, err := sdk.AccAddressFromBech32(msg.SenderAddress)
+	if err != nil {
+		return nil, errorsmod.Wrapf(err, "invalid sender address %s", msg.SenderAddress)
 	}
 
 	if msg.Amount == nil || msg.Amount.Empty() {
@@ -60,12 +61,6 @@ func (ms msgServer) DistributeTokens(
 
 	if !authorized {
 		return nil, types.ErrDripNotAllowed
-	}
-
-	// Get sender
-	sender, err := sdk.AccAddressFromBech32(msg.SenderAddress)
-	if err != nil {
-		return nil, err
 	}
 
 	if err := ms.SendCoinsFromAccountToFeeCollector(ctx, sender, msg.Amount); err != nil {


### PR DESCRIPTION
…dundant error wrap

DistributeTokens called sdk.AccAddressFromBech32 twice on the same address: once to validate (discarding the result with _) and again after the authorization check to actually use the value. The second parse is redundant — if the first succeeded, the second always will too.

Also fixed the error message on the failed parse: the original used errorsmod.Wrapf(err, "invalid sender address: %s", err.Error()) which embeds err.Error() in the format string *and* wraps err, causing the underlying error to appear twice in the error chain. Changed to errorsmod.Wrapf(err, "invalid sender address %s", msg.SenderAddress) which includes the address for context without duplicating the error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sender address validation during token distribution.
  * Error messages now preserve the original sender address when parsing fails.
  * Reduced duplicate address parsing and reused the validated sender for the transfer step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->