### PR TITLE
ci: upload junod binaries on GitHub Releases (#1220)

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,0 +1,55 @@
+name: Release Binaries
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to upload binaries for (for example `v30.0.0`)
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  upload-release-binaries:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve release tag
+        id: resolve-tag
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          tag="${RELEASE_TAG:-$INPUT_TAG}"
+          if [ -z "$tag" ]; then
+            echo "Release tag is required"
+            exit 1
+          fi
+
+          echo "release_tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.resolve-tag.outputs.release_tag }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.25.10
+
+      - name: Build junod
+        run: VERSION="${{ steps.resolve-tag.outputs.release_tag }}" LEDGER_ENABLED=false make build
+
+      - name: Create release assets
+        run: |
+          cp bin/junod junod
+          sha256sum junod > junod_sha256.txt
+
+      - name: Upload release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ steps.resolve-tag.outputs.release_tag }}" junod junod_sha256.txt --clobber

--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -3,6 +3,7 @@ name: Dispatch Release to juno-std
 on:
   release:
     types: [released]
+
 env:
   JUNO_REPO: "https://github.com/CosmosContracts/juno.git"
   JUNO_DIR: "proto"
@@ -43,7 +44,7 @@ jobs:
 
             // Determine release_tag and flags based on event type or manual inputs
             const inputs = (context.payload && context.payload.inputs) || {};
-            const releaseTag = inputs.release_tag || '';
+            const releaseTag = inputs.release_tag || context.payload.release?.tag_name || '';
             const isDraft = String(inputs.is_draft || '').toLowerCase() === 'true';
             const isPrerelease = String(inputs.is_prerelease || '').toLowerCase() === 'true';
 
@@ -66,7 +67,7 @@ jobs:
                 repo: process.env.COSMOS_SDK_REPO,
                 rev: process.env.COSMOS_SDK_REV,
                 dir: process.env.COSMOS_SDK_DIR,
-                exclude_mods: ['cosmos/benchmark', 'cosmos/counter', 'cosmos/epochs', 'cosmos/protocolpool],
+                exclude_mods: ['cosmos/benchmark', 'cosmos/counter', 'cosmos/epochs', 'cosmos/protocolpool'],
               },
               wasmd: {
                 name: 'wasm',

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -14,6 +14,20 @@ In the past, some releases have been consensus-breaking but only incremented a m
 the
 **Only patch versions, i.e. `x.x.1 -> x.x.2`, or `3.1.0 -> 3.1.1` are guaranteed to be non-consensus breaking.**
 
+## Obtaining binaries
+
+When `.github/workflows/release-binaries.yml` runs for a published GitHub release, it uploads two release assets for the tag:
+
+- `junod`
+- `junod_sha256.txt`
+
+For the existing `v30.0.0` release in `CosmosContracts/juno#1220`, maintainers can backfill those assets by running the `Release Binaries` workflow manually with `tag=v30.0.0`.
+
+Until that workflow has run for `v30.0.0`, use one of these install paths instead:
+
+- Docker: `ghcr.io/cosmoscontracts/juno:v30.0.0`
+- Source install: `git checkout v30.0.0 && make install`
+
 ## Scheduled upgrade via governance
 
 For a SoftwareUpgradeProposal via governance:


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/release-binaries.yml` to build `junod` and upload `junod` + `junod_sha256.txt` on published releases (and via `workflow_dispatch` for backfill).
- Documents interim install for v30.0.0 (Docker `ghcr.io/cosmoscontracts/juno:v30.0.0` or `make install`) in `RELEASES.md`.
- Fixes `release-dispatch.yml` to read `release.tag_name` on release events (v30 dispatch failed with empty tag).

Fixes #1220

## Test plan
- [ ] After merge, run **Release Binaries** workflow with `workflow_dispatch` and tag `v30.0.0`
- [ ] Confirm https://github.com/CosmosContracts/juno/releases/tag/v30.0.0 has `junod` and `junod_sha256.txt`
- [ ] `sha256sum -c junod_sha256.txt` validates the binary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release builds now automatically produce downloadable `junod` binaries and SHA-256 checksums.
  * Release assets can be generated for published releases or manual requests.

* **Documentation**
  * Added instructions for obtaining release binaries, including guidance for older releases and alternative installation methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->